### PR TITLE
v0.6.0: sección Datos + fix line chart + versionado

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+Todos los cambios notables de la app van acá.
+
+Formato basado en [Keep a Changelog](https://keepachangelog.com/es/1.1.0/),
+versionado [SemVer](https://semver.org/lang/es/) adaptado a app web:
+
+- **MAJOR** (X.0.0): cambio estructural, nueva línea de análisis, breaking.
+- **MINOR** (0.X.0): feature nueva visible al usuario.
+- **PATCH** (0.0.X): fix, polish UX, mejora menor.
+
+---
+
+## [0.6.0] · 2026-05-02
+
+Primer release con CHANGELOG. Versiones anteriores no están documentadas
+acá; ver historial de issues cerrados y `git log` para detalle.
+
+### Added
+
+- Sección **Datos** en el sidebar con descarga del panel longitudinal
+  completo en Parquet y CSV (gzip), diccionario de variables descargable y
+  aviso de limitaciones metodológicas. (#35)
+- Generación de `data_output/panel_runtime.csv.gz` integrada al pipeline
+  ETL de actualización mensual.
+- Versionado de la app: `R/version.R`, `CHANGELOG.md` y versión visible en
+  el footer del sidebar.
+- Record de cambios a comunicar en `comunicaciones/cambios_a_comunicar.md`
+  para alimentar contenido de redes sociales.
+
+### Fixed
+
+- Eje Y del line chart se recalcula al togglear series via legend
+  interactiva. (#32)
+- Eje X del line chart mostraba `[o,[o,...` por nested categories sin el
+  plugin `grouped-categories`. Reemplazado por categorías planas + plot
+  bands fantasma con label de año debajo del eje. (#40)
+
+### Changed
+
+- Cache-busting automático de assets estáticos (`style.css`, `script.js`,
+  `highlight.min.js`): el `href` ahora incluye `?v=<mtime>` y el browser
+  invalida cache cuando el archivo cambia.

--- a/ETL/02-transform.R
+++ b/ETL/02-transform.R
@@ -41,11 +41,23 @@ if (nrow(df_tasas_formalidad_amp) > 0) {
 }
 
 
-### Application dependencies (CSS/JS estáticos)
+### Application dependencies (CSS/JS estáticos).
+### Cache-busting: append ?v=<mtime> a los assets propios para que el
+### navegador los invalide cuando cambiamos el archivo. Los CDN externos
+### (a11y-dark) van versionados upstream, no necesitan busting.
+asset_url <- function(file) {
+  ruta <- file.path("www", file)
+  if (file.exists(ruta)) {
+    paste0(file, "?v=", as.integer(file.info(ruta)$mtime))
+  } else {
+    file
+  }
+}
+
 include_styles <- tags$head(
-  tags$link(rel = "stylesheet", type = "text/css", href = "style.css"),
-  tags$script(src = "script.js"),
-  tags$script(src = "highlight.min.js"),
+  tags$link(rel = "stylesheet", type = "text/css", href = asset_url("style.css")),
+  tags$script(src = asset_url("script.js")),
+  tags$script(src = asset_url("highlight.min.js")),
   tags$script("hljs.highlightAll();"),
   tags$link(href = "a11y-dark.min.css", rel = "stylesheet")
 )

--- a/ETL/09-build_paneles_runtime.R
+++ b/ETL/09-build_paneles_runtime.R
@@ -88,6 +88,13 @@ tamanio_mb <- round(file.size(path_out) / 1024 / 1024, 2)
 cat(glue::glue("\n✔ Escrito: {path_out} ({tamanio_mb} MB en disco)\n"))
 cat(glue::glue("  Dúos contenidos: {dplyr::n_distinct(panel_runtime[, c('anio_0', 'trim_0')])}\n\n"))
 
+### CSV gzip espejo del parquet para descarga universal (issue #35).
+### Pesa ~23 MB con compresión, vs ~199 MB sin comprimir. readr::write_csv
+### detecta la extensión .gz y comprime automáticamente.
+path_out_csv <- "data_output/panel_runtime.csv.gz"
+readr::write_csv(panel_runtime, path_out_csv)
+cat(glue::glue("✔ Escrito: {path_out_csv} ({round(file.size(path_out_csv)/1024/1024, 2)} MB en disco)\n\n"))
+
 ### Sanity check: leer y filtrar uno de los dúos más recientes para
 ### verificar que el resultado coincide con armo_base_panel() directo.
 duo_test <- duos_validos |> dplyr::slice_tail(n = 1)

--- a/R/panel_descarga.R
+++ b/R/panel_descarga.R
@@ -1,0 +1,241 @@
+### Panel "Datos" (issue #35).
+###
+### Expone el dataset principal del panel longitudinal en dos formatos
+### (parquet + CSV gzip) y el diccionario de variables como CSV.
+### Server-side: los downloadHandler() viven en app.R y leen los archivos
+### de data_output/ directamente. No hay procesamiento en runtime.
+###
+### Tracking: cada botón dispara un evento GA4 'dataset_download' con
+### {dataset, format} via onclick (el click burbujea al wrapper). Si gtag
+### no está cargado (consent denegado, GA4_DISABLE), el evento se descarta.
+
+
+### Diccionario de las 31 columnas del panel_runtime. Se sirve como CSV
+### descargable y también lo usamos para validar la cobertura del panel.
+columnas_panel_runtime <- tibble::tribble(
+  ~Variable,                ~Descripción,
+  "anio_0",                 "Año del primer trimestre del dúo (t0).",
+  "trim_0",                 "Trimestre del primer trimestre del dúo (t0).",
+  "CODUSU",                 "ID de vivienda. Clave de pareo del panel junto con NRO_HOGAR y COMPONENTE.",
+  "NRO_HOGAR",              "Número de hogar dentro de la vivienda.",
+  "COMPONENTE",             "Número de persona dentro del hogar.",
+  "ANO4",                   "Año del registro en t0.",
+  "TRIMESTRE",              "Trimestre del registro en t0.",
+  "CH04",                   "Sexo (1=Varón, 2=Mujer).",
+  "CH06",                   "Edad en años cumplidos.",
+  "ESTADO",                 "Condición de actividad en t0 (1=Ocupado, 2=Desocupado, 3=Inactivo, 4=Menor de 10 años).",
+  "CAT_OCUP",               "Categoría ocupacional en t0 (1=Patrón, 2=Cuenta propia, 3=Asalariado, 4=Trab. familiar).",
+  "PP07H",                  "Descuento jubilatorio (asalariados, t0). 1=Sí, 2=No.",
+  "PP05I",                  "Monotributo cuenta propia en t0 (disponible desde 2023-T4).",
+  "PP05K",                  "Aportes propios cuenta propia en t0 (disponible desde 2023-T4).",
+  "formalidad",             "Formalidad clásica en t0 (1=Formal, 2=Informal, NA si no aplica). Definida solo para asalariados.",
+  "formalidad_ampliada",    "Formalidad ampliada en t0 (todos los ocupados con info de aportes).",
+  "PONDERA",                "Factor de expansión de la persona en t0.",
+  "Periodo",                "Etiqueta del dúo trimestral. Formato 'YYYY_tA-tB'.",
+  "ANO4_t1",                "Año del registro en t1 (segundo trimestre del dúo).",
+  "TRIMESTRE_t1",           "Trimestre del registro en t1.",
+  "CH04_t1",                "Sexo declarado en t1. Diferencia respecto a CH04 = inconsistencia.",
+  "CH06_t1",                "Edad en t1. Diferencia esperada con CH06: 0 o +1 año.",
+  "ESTADO_t1",              "Condición de actividad en t1.",
+  "CAT_OCUP_t1",            "Categoría ocupacional en t1.",
+  "PP07H_t1",               "Descuento jubilatorio en t1.",
+  "PP05I_t1",               "Monotributo cuenta propia en t1.",
+  "PP05K_t1",               "Aportes propios cuenta propia en t1.",
+  "formalidad_t1",          "Formalidad clásica en t1.",
+  "formalidad_ampliada_t1", "Formalidad ampliada en t1.",
+  "PONDERA_t1",             "Factor de expansión de la persona en t1.",
+  "consistencia",           "Flag de consistencia entre t0 y t1 (eph::organize_panels). FALSE = inconsistencia detectada (sexo distinto, edad imposible, etc.)."
+)
+
+
+### Helper: downloadButton con tracking GA4 client-side via onclick
+### en el wrapper (el click burbujea, dispara el evento, sigue la descarga).
+download_btn_tracked <- function(output_id,
+                                 label,
+                                 dataset,
+                                 format,
+                                 size_label,
+                                 icon_name = "download") {
+  onclick_js <- sprintf(
+    "if(typeof gtag==='function'){gtag('event','dataset_download',{dataset:'%s',format:'%s'});}",
+    dataset, format
+  )
+  tags$div(
+    class = "descarga-btn-wrapper",
+    onclick = onclick_js,
+    shiny::downloadButton(
+      output_id,
+      label = paste0(label, "  (", size_label, ")"),
+      icon  = shiny::icon(icon_name),
+      class = "btn-descarga"
+    )
+  )
+}
+
+
+### Helper: item de dropdown que dispara una descarga vía downloadLink.
+### shiny::downloadLink renderiza como <a href="session/.../download/...">,
+### le sumamos class="dropdown-item" para tomar el estilo del menú Bootstrap
+### y un onclick para tracking GA4.
+download_dropdown_item <- function(output_id,
+                                   label,
+                                   dataset,
+                                   format,
+                                   size_label,
+                                   icon_name) {
+  onclick_js <- sprintf(
+    "if(typeof gtag==='function'){gtag('event','dataset_download',{dataset:'%s',format:'%s'});}",
+    dataset, format
+  )
+  tags$li(
+    shiny::downloadLink(
+      output_id,
+      label = tagList(
+        shiny::icon(icon_name),
+        tags$span(label),
+        tags$span(class = "dropdown-item-size", size_label)
+      ),
+      class = "dropdown-item",
+      onclick = onclick_js
+    )
+  )
+}
+
+
+panel_descarga <- bslib::nav_panel(
+  title = "Datos",
+  icon  = bsicons::bs_icon("cloud-download"),
+
+  tags$div(
+    class = "panel-descarga",
+    style = "max-width: 1100px;",
+
+    ### Hero
+    tags$div(
+      class = "descarga-hero",
+      tags$h2("Descargá el dataset", class = "descarga-hero-title"),
+      tags$p(
+        class = "descarga-hero-subtitle",
+        "La app construye un panel longitudinal a partir del ",
+        tags$strong("microdato de la EPH"), " para responder cuántas personas ",
+        "permanecen, salen o entran a una condición laboral entre dos trimestres. ",
+        "Podés bajar el panel armado para reutilizarlo en tus propios análisis."
+      )
+    ),
+
+    ### Grid de tarjetas: dataset + diccionario (mismo lenguaje que landing-cards)
+    tags$div(
+      class = "descarga-cards-grid",
+
+      ### Tarjeta 1: Dataset (con dropdown de formatos)
+      tags$div(
+        class = "descarga-card",
+        shiny::icon("database", class = "descarga-card-icon"),
+        tags$h4("Panel longitudinal completo",
+                class = "descarga-card-title"),
+        tags$p(class = "descarga-card-meta",
+               "1.86 M filas · 31 columnas · 2003-T1 a 2025-T4"),
+        tags$p(class = "descarga-card-desc",
+               "Personas EPH vinculadas entre t0 y t1 con todas las ",
+               "variables usadas por la app. CSV viene en gzip; R, Python ",
+               "y Stata 18+ lo leen directamente."),
+        tags$div(
+          class = "descarga-card-action dropdown",
+          tags$button(
+            class = "btn-descarga dropdown-toggle",
+            type = "button",
+            `data-bs-toggle` = "dropdown",
+            `aria-expanded`  = "false",
+            shiny::icon("download"),
+            "Descargar"
+          ),
+          tags$ul(
+            class = "dropdown-menu",
+            download_dropdown_item(
+              "descarga_panel_runtime_parquet",
+              label      = "Parquet",
+              dataset    = "panel_runtime", format = "parquet",
+              size_label = "22 MB",
+              icon_name  = "file-zipper"
+            ),
+            download_dropdown_item(
+              "descarga_panel_runtime_csv",
+              label      = "CSV (gzip)",
+              dataset    = "panel_runtime", format = "csv_gz",
+              size_label = "23 MB",
+              icon_name  = "file-csv"
+            )
+          )
+        )
+      ),
+
+      ### Tarjeta 2: Diccionario (botón directo)
+      tags$div(
+        class = "descarga-card",
+        shiny::icon("book", class = "descarga-card-icon"),
+        tags$h4("Diccionario de variables", class = "descarga-card-title"),
+        tags$p(class = "descarga-card-meta",
+               "31 variables · CSV"),
+        tags$p(class = "descarga-card-desc",
+               "Las 31 columnas del panel con su descripción. ",
+               "Para más contexto sobre cada variable, ver ",
+               tags$strong("Metadata > Glosario"), "."),
+        tags$div(
+          class = "descarga-card-action",
+          download_btn_tracked(
+            "descarga_diccionario_csv",
+            label      = "Descargar CSV",
+            dataset    = "diccionario", format = "csv",
+            size_label = "3 KB",
+            icon_name  = "download"
+          )
+        )
+      )
+    ),
+
+    ### Aviso metodológico al pie (full width, treatment amber)
+    tags$div(
+      class = "descarga-aviso",
+      tags$p(
+        class = "descarga-aviso-title",
+        shiny::icon("triangle-exclamation"),
+        "Limitaciones metodológicas"
+      ),
+      tags$ul(
+        tags$li(
+          tags$strong("Intervención INDEC 2007-2015: "),
+          "el propio organismo desestima estas series para el análisis ",
+          "del mercado de trabajo. Considerá excluirlas o reportarlas con reservas."
+        ),
+        tags$li(
+          tags$strong("Panel balanceado: "),
+          "el dataset solo incluye personas presentes en t0 ",
+          tags$em("y"), " en t1. Las personas que la EPH pierde entre ",
+          "trimestres (atrición) quedan fuera."
+        ),
+        tags$li(
+          tags$strong("Inconsistencias entre t0 y t1: "),
+          "el flag ", tags$code("consistencia"), " marca casos donde ",
+          "el algoritmo detectó variables estables (sexo, edad) que cambiaron ",
+          "de forma imposible."
+        ),
+        tags$li(
+          tags$strong("Cobertura: "),
+          "el panel cubre desde 2003-T1 hasta el último trimestre publicado por INDEC."
+        )
+      ),
+      tags$p(
+        tags$strong("Fuente original: "),
+        tags$a("INDEC · EPH",
+               href   = "https://www.indec.gob.ar/indec/web/Institucional-Indec-BasesDeDatos",
+               target = "_blank",
+               style  = "color: #405BFF;"),
+        " · Procesamiento con ",
+        tags$a("{eph}", href = "https://docs.ropensci.org/eph/", target = "_blank",
+               style = "color: #405BFF;"),
+        ".",
+        style = "margin-top: 0.75rem; color: #404040; margin-bottom: 0;"
+      )
+    )
+  )
+)

--- a/R/utils_analisis.R
+++ b/R/utils_analisis.R
@@ -320,24 +320,47 @@ arma_line_chart_areaspline <- function(df_data,
     )))
   }
 
-  ### Construir nested categories: año (parent) + dúo trimestral (child).
-  ### Highcharts soporta categorías agrupadas pasando una lista de objetos
-  ### {name: <año>, categories: [<duos>]}. Esto produce el efecto de doble
-  ### leyenda en el eje X sin tener que rotar el texto.
-  ###
-  ### Como las categorías hijas son SOLO el dúo (sin año), los datos también
-  ### tienen que dejar de referenciar el periodo completo "YYYY_tA-tB" y
-  ### pasar a usar índices posicionales. Por eso pasamos `data` como vector
-  ### de y values en orden de las categorías aplanadas.
+  ### Categorías planas "YYYY t1-t2" (issue #40). Highcharts core NO
+  ### soporta nested {name, categories} sin el plugin grouped-categories
+  ### (que no está cargado): la estructura se serializa como
+  ### "[object Object],[object Object],..." y el eje X queda roto.
+  ### En lugar del plugin: categorías planas + plotBands fantasma por
+  ### año (color transparente, label = año debajo del eje X) que
+  ### simulan la doble jerarquía abarcando los 4 dúos del año.
   parsed <- stringr::str_match(periodos_visibles,
                                "^(\\d{4})_(t\\d-t\\d)$")
   anios_seq <- parsed[, 2]
   duos_seq  <- parsed[, 3]
 
-  categorias_nested <- lapply(unique(anios_seq), function(a) {
-    list(name = a,
-         categories = as.list(duos_seq[anios_seq == a]))
-  })
+  categorias_planas <- paste(anios_seq, duos_seq)
+
+  ### PlotBands fantasma por año: color transparente, label = año
+  ### posicionado debajo del eje X (verticalAlign='bottom' + y > 0
+  ### empuja el label fuera del plot area, sobre el espacio reservado
+  ### por chart.marginBottom). Cada band cubre los índices del año.
+  for (y in unique(anios_seq)) {
+    idxs <- which(anios_seq == y)
+    plot_bands <- c(plot_bands, list(list(
+      from = min(idxs) - 1L,
+      to   = max(idxs) - 1L,
+      color = "rgba(0,0,0,0)",
+      label = list(
+        text = y,
+        align = "center",
+        verticalAlign = "bottom",
+        ### y = offset hacia abajo desde el borde inferior del plot
+        ### area. 48 ubica el año en la franja entre las labels de
+        ### dúo (que ocupan los primeros ~30px) y la caption (que
+        ### highcharter posiciona en los últimos ~30px del chart).
+        y = 48,
+        style = list(
+          fontWeight = "600",
+          fontSize = "0.85em",
+          color = "#191919"
+        )
+      )
+    )))
+  }
 
   ### Datos por serie: para cada `to` (categoría destino), un vector de
   ### y values en el orden exacto de periodos_visibles. Cada punto se
@@ -360,7 +383,13 @@ arma_line_chart_areaspline <- function(df_data,
     })
 
   hc <- highcharter::highchart() |>
-    highcharter::hc_chart(type = "areaspline", zoomType = "x") |>
+    highcharter::hc_chart(type = "areaspline", zoomType = "x",
+                           ### Reserva espacio debajo del eje X para
+                           ### los labels de dúo (~30px), los labels de
+                           ### año del plotBand fantasma (~20px) y la
+                           ### caption (~30px), con margen entre cada
+                           ### bloque (issue #40).
+                           marginBottom = 110) |>
     highcharter::hc_add_theme(hc_theme_estacion_r) |>
     ### Paleta diferenciada para line charts con 3+ series (issue #26).
     highcharter::hc_colors(c("#405BFF", "#FF7043", "#EAFF38", "#7CB342")) |>
@@ -379,14 +408,61 @@ arma_line_chart_areaspline <- function(df_data,
                        color = "#191919",
                        fontWeight = "600")
         )
+      ),
+      ### Recalcular eje Y al togglear series via legend (issue #32).
+      ### Usa la misma lógica que el primer render: padding 15% del rango,
+      ### piso 1pp, clamp 0-100. setTimeout porque Highcharts actualiza
+      ### series.visible DESPUÉS de disparar el evento.
+      series = list(
+        events = list(
+          legendItemClick = htmlwidgets::JS("function() {
+            var chart = this.chart;
+            setTimeout(function() {
+              var visiblesY = [];
+              chart.series.forEach(function(s) {
+                if (s.visible) {
+                  s.points.forEach(function(p) {
+                    if (p.y !== null && p.y !== undefined) visiblesY.push(p.y);
+                  });
+                }
+              });
+              if (visiblesY.length === 0) return;
+              var minV = Math.min.apply(null, visiblesY);
+              var maxV = Math.max.apply(null, visiblesY);
+              var pad = Math.max(1, (maxV - minV) * 0.15);
+              chart.yAxis[0].update({
+                min: Math.max(0, minV - pad),
+                max: Math.min(100, maxV + pad)
+              }, true);
+            }, 50);
+          }")
+        )
       )
     ) |>
     highcharter::hc_xAxis(
       title    = list(text = NULL),
-      categories = categorias_nested,
+      categories = categorias_planas,
       plotBands = plot_bands,
-      labels   = list(rotation = 0,
-                      style = list(fontSize = "0.8em"))
+      labels   = list(
+        useHTML = TRUE,
+        rotation = 0,
+        style = list(fontSize = "0.65em"),
+        ### Muestra todos los dúos en 2 líneas (t1- arriba, t2 abajo)
+        ### con fuente reducida para evitar superposición con muchos
+        ### puntos en el eje. El año lo aporta el plotBand fantasma
+        ### posicionado debajo del eje. tick_interval queda sin uso
+        ### (legado de labels.step previo).
+        formatter = htmlwidgets::JS("function() {
+          var partes = String(this.value).split(' ');
+          if (partes.length < 2) return '';
+          var subs = partes[1].split('-');
+          if (subs.length < 2) return '';
+          return '<div style=\"text-align:center;line-height:1\">' +
+                 '<div>' + subs[0] + '-</div>' +
+                 '<div>' + subs[1] + '</div>' +
+                 '</div>';
+        }")
+      )
     )
 
   for (s in series_lista) {

--- a/R/version.R
+++ b/R/version.R
@@ -1,0 +1,13 @@
+### Versión de la app.
+###
+### Esquema SemVer adaptado a app web (no librería):
+###   MAJOR (X.0.0): cambio estructural / nueva línea de análisis / breaking.
+###   MINOR (0.X.0): feature nueva visible al usuario.
+###   PATCH (0.0.X): fix, polish UX, mejora menor.
+###
+### Al hacer release: bumpear acá + agregar entrada en CHANGELOG.md +
+### tag git `vX.Y.Z` en el commit del merge.
+###
+### Se muestra en el sidebar footer (app.R) y queda disponible para
+### eventuales evento GA4 con dimensión custom 'app_version'.
+APP_VERSION <- "0.6.0"

--- a/app.R
+++ b/app.R
@@ -279,6 +279,10 @@ ui <- page_fillable(
       nav_item_paquete_eph
     ),
 
+    ### Datos: descargas del panel longitudinal y diccionario (issue #35).
+    ### Va al mismo nivel que Metadata porque "datos" no es metadata.
+    panel_descarga,
+
     ### Footer con créditos, fuente y feedback. Como nav_item al pie del
     ### sidebar para que esté siempre visible sin estorbar la navegación.
     nav_item(
@@ -304,6 +308,10 @@ ui <- page_fillable(
           tags$a("Estación R", href = "https://estacion-r.com",
                  target = "_blank", class = "sidebar-footer-link"),
           " · App en desarrollo"
+        ),
+        tags$p(
+          class = "sidebar-footer-version",
+          paste0("v", APP_VERSION)
         )
       )
     )
@@ -392,6 +400,40 @@ server <- function(input, output, session) {
         locations = gt::cells_body(columns = Variable)
       )
   })
+
+  ### --------------------------------------------------------------------
+  ### Descargas del panel longitudinal (issue #35).
+  ### El parquet y el CSV gzip se sirven copiando archivos de
+  ### data_output/ (sin procesamiento en runtime). El diccionario se
+  ### genera on-demand a partir del tibble columnas_panel_runtime.
+  ### El tracking GA4 se dispara client-side (ver download_btn_tracked).
+  ### --------------------------------------------------------------------
+
+  servir_archivo <- function(ruta_relativa, nombre_descarga) {
+    shiny::downloadHandler(
+      filename = function() nombre_descarga,
+      content  = function(file) file.copy(ruta_relativa, file),
+      contentType = NA
+    )
+  }
+
+  output$descarga_panel_runtime_parquet <- servir_archivo(
+    "data_output/panel_runtime.parquet",
+    paste0("eph_panel_runtime_", format(Sys.Date(), "%Y%m%d"), ".parquet"))
+
+  output$descarga_panel_runtime_csv <- servir_archivo(
+    "data_output/panel_runtime.csv.gz",
+    paste0("eph_panel_runtime_", format(Sys.Date(), "%Y%m%d"), ".csv.gz"))
+
+  output$descarga_diccionario_csv <- shiny::downloadHandler(
+    filename = function() {
+      paste0("eph_panel_diccionario_", format(Sys.Date(), "%Y%m%d"), ".csv")
+    },
+    content = function(file) {
+      readr::write_csv(columnas_panel_runtime, file)
+    },
+    contentType = "text/csv"
+  )
 }
 
 

--- a/comunicaciones/2026-05-01_post_dia_trabajador.md
+++ b/comunicaciones/2026-05-01_post_dia_trabajador.md
@@ -1,0 +1,52 @@
+# Post redes — 1° de mayo 2026, Día del Trabajador
+
+> Lanzamiento reedición app shiny_eph_panel
+> Fecha publicación: 2026-05-01
+> Canales: LinkedIn (versión completa) — adaptar para Twitter si corresponde
+
+---
+
+Hoy se conmemora a quienes sostienen, con su trabajo, todo lo demás.
+¡Feliz día del trabajador! 🛠️
+
+Y qué mejor fecha para compartir una herramienta que va, justamente,
+sobre el trabajo: 📊 una app para analizar el mercado laboral
+argentino con la técnica de panel y datos de la EPH. Reedición fresca
+de los últimos días.
+
+¿Qué tiene de especial esta técnica? Implica un análisis longitudinal:
+ya no la "foto" de un período, sino la "película" — la misma persona
+en dos momentos distintos.
+
+Un ejemplo de lo que esa "película" deja ver: el pasaje de asalariados
+a cuenta propia está hoy en los valores más altos de toda la serie.
+Un movimiento difícil de captar con los indicadores tradicionales,
+pero que el panel revela con claridad.
+
+Son pocos los operativos de encuestas a hogares en el mundo que
+permiten este tipo de análisis, y las razones no son menores:
+desafíos muestrales ("no te da el n", diría una muestrista) y
+conceptuales, sumados a la calidad de la información.
+
+Durante mi estadía en la EPH dediqué gran parte de mi tiempo a
+analizar cómo se comportaban los paneles de la encuesta. Siempre
+quise armar una herramienta para compartir lo que aprendí allí con
+el resto de la comunidad. Así que ¡ahí va!
+
+Si querés jugar con la app, te dejo el link en comentarios 👇🏼
+Mañana subo un artículo al blog contándote más sobre esta potente
+forma de analizar datos con R.
+
+🔗 https://estacionr.shinyapps.io/shiny_eph_panel/
+
+#EPH #MercadoLaboral #RStats #DatosPúblicos #estacionR
+
+---
+
+## Notas
+
+- **Hallazgos mencionados:**
+  - Pasaje asalariados → cuenta propia en máximos de la serie (incluido en el cuerpo).
+  - Calidad del panel: merma en % de panel encontrado a lo largo del tiempo (no incluido en redes, queda para el blog).
+- **Follow-up:** artículo de blog el 2026-05-02 con desarrollo completo de los hallazgos.
+- **Link app:** https://estacionr.shinyapps.io/shiny_eph_panel/

--- a/comunicaciones/cambios_a_comunicar.md
+++ b/comunicaciones/cambios_a_comunicar.md
@@ -1,0 +1,58 @@
+# Cambios a comunicar en redes
+
+> Registro de cambios y mejoras del dashboard que ameritan post / contenido en
+> redes sociales (Twitter, LinkedIn, Instagram, Telegram). Cada entrada queda
+> "pendiente" hasta que se publique. Para redacción usar los lineamientos de
+> `.claude/estilo-escritura-pablo.md` y delegar al agente `estacion-r-social-media`
+> cuando corresponda.
+
+## Formato de cada entrada
+
+```
+### [fecha-implementación] · Título corto
+- **Estado:** pendiente | publicado (link)
+- **Qué cambió:** descripción técnica corta.
+- **Valor para el usuario:** por qué le importa al investigador / docente / alumno.
+- **Ángulo de copy:** 1-2 ideas de gancho narrativo.
+- **Asset visual:** screenshot, GIF, link a la pestaña relevante.
+- **Audiencia prioritaria:** Twitter (ciencias sociales argentinas), LinkedIn
+  (analistas de datos sector público), Telegram (alumnos Estación R).
+- **Issue / commit:** referencia.
+```
+
+---
+
+## Pendientes
+
+### 2026-05-02 · Nueva sección "Datos" para descargar el panel longitudinal
+
+- **Estado:** pendiente
+- **Qué cambió:** se agregó una sección **Datos** en el sidebar del dashboard
+  donde cualquiera puede bajar el panel longitudinal completo de la EPH ya
+  armado, en Parquet o CSV (gzip). Suma también un diccionario de variables
+  descargable y aviso metodológico (intervención INDEC, panel balanceado,
+  inconsistencias, cobertura).
+- **Valor para el usuario:** el panel longitudinal de la EPH no es trivial de
+  armar (hay que parear personas entre trimestres con `eph::organize_panels()`
+  y validar consistencia). Hasta ahora la app lo construía internamente pero
+  no lo exponía. Ahora cualquier investigador, docente o alumno puede usarlo
+  como insumo en sus análisis sin reproducir la lógica de pareo.
+- **Ángulo de copy:**
+  1. *"Si alguna vez quisiste analizar quién entra y sale del empleo formal en
+     Argentina pero te frenaste al armar el panel, esto es para vos."*
+  2. *"Sumamos descarga del panel longitudinal de la EPH. 1.86 M filas, 31
+     columnas, 2003 a 2025."*
+  3. Educativo: explicar qué es el esquema 2-2-2 y por qué hay que parear
+     personas para análisis longitudinal (con link al dashboard).
+- **Asset visual:** screenshot de la sección Datos (las 2 tarjetas con dropdown
+  + botón). Capturado durante implementación, pendiente de versión definitiva.
+- **Audiencia prioritaria:** Twitter (ciencias sociales argentinas, mercado de
+  trabajo, analistas), LinkedIn (sector público, consultores). Para Telegram
+  Estación R va más adelante con un tip vinculado.
+- **Issue / commit:** issue #35.
+
+---
+
+## Publicados
+
+(vacío por ahora)

--- a/www/style.css
+++ b/www/style.css
@@ -354,6 +354,14 @@
   color: #888;
   margin-top: 0.4rem !important;
 }
+.sidebar-footer-version {
+  font-size: 0.7rem;
+  color: #b0b0b0;
+  font-family: 'Ubuntu Mono', monospace;
+  margin-top: 0.15rem !important;
+  margin-bottom: 0 !important;
+  letter-spacing: 0.02em;
+}
 
 /* Alerta del período de intervención INDEC (Foto y Comparar). Aparece
    debajo del filter_query cuando el panel seleccionado cae en 2007-2015.
@@ -734,4 +742,195 @@ input:checked + .slider:before {
   .cookie-banner-actions {
     justify-content: flex-end;
   }
+}
+
+/* ──────────────────────────────────────────────────────────────────
+   Panel "Datos" — sección de descarga (issue #35)
+   Reusa el lenguaje de las landing-cards de Inicio.
+   ────────────────────────────────────────────────────────────────── */
+
+.descarga-hero {
+  padding-bottom: 1.25rem;
+  margin-bottom: 1.5rem;
+  border-bottom: 1px solid rgba(25, 25, 25, 0.07);
+}
+.descarga-hero-title {
+  font-family: 'Array', 'Ubuntu', sans-serif;
+  font-weight: 700;
+  font-size: 1.6rem;
+  color: #191919;
+  margin-bottom: 0.5rem;
+}
+.descarga-hero-subtitle {
+  font-size: 1.02em;
+  color: #505050;
+  line-height: 1.55;
+  margin-bottom: 0;
+  max-width: 720px;
+}
+
+/* Grid de tarjetas (mismo patrón que landing-cards-grid) */
+.descarga-cards-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.75rem;
+}
+@media (max-width: 900px) {
+  .descarga-cards-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Tarjeta — mismo lenguaje visual que .landing-card pero sin link wrapper */
+.descarga-card {
+  background-color: #FFFFFF;
+  border: 1px solid rgba(64, 91, 255, 0.18);
+  border-radius: 12px;
+  padding: 1.5rem 1.25rem 1.25rem;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  display: flex;
+  flex-direction: column;
+}
+.descarga-card:hover {
+  border-color: #405BFF;
+  box-shadow: 0 6px 18px rgba(64, 91, 255, 0.12);
+}
+.descarga-card-icon {
+  font-size: 1.6rem;
+  color: #405BFF;
+  margin-bottom: 0.6rem;
+  display: block;
+}
+.descarga-card-title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin: 0 0 0.4rem 0;
+  color: #191919;
+}
+.descarga-card-meta {
+  font-size: 0.85rem;
+  color: #405BFF;
+  font-weight: 600;
+  margin: 0 0 0.5rem 0;
+  letter-spacing: 0.01em;
+}
+.descarga-card-desc {
+  font-size: 0.92rem;
+  color: #555;
+  margin: 0 0 1rem 0;
+  line-height: 1.45;
+  flex-grow: 1;
+}
+
+/* Acción al pie de la tarjeta — botón único o dropdown */
+.descarga-card-action {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+/* Botón principal dentro de tarjeta (azul sólido, hover oscuro) */
+.btn-descarga {
+  background: #405BFF;
+  color: #FFFFFF !important;
+  border: 1.5px solid #405BFF;
+  border-radius: 6px;
+  padding: 0.5rem 1rem;
+  font-weight: 600;
+  font-size: 0.95em;
+  transition: background 140ms ease, border-color 140ms ease, box-shadow 140ms ease;
+  text-decoration: none !important;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.btn-descarga:hover {
+  background: #1839F4;
+  border-color: #1839F4;
+  color: #FFFFFF !important;
+  box-shadow: 0 2px 8px rgba(64, 91, 255, 0.25);
+}
+.btn-descarga:focus-visible {
+  outline: 2px solid #EAFF38;
+  outline-offset: 3px;
+}
+.btn-descarga .fa,
+.btn-descarga .fas,
+.btn-descarga .far {
+  font-size: 0.95em;
+}
+.descarga-btn-wrapper {
+  display: inline-block;
+}
+
+/* Dropdown de formatos (Bootstrap 5 nativo, restilado) */
+.descarga-card-action .dropdown-menu {
+  border: 1px solid rgba(64, 91, 255, 0.18);
+  border-radius: 8px;
+  box-shadow: 0 6px 18px rgba(64, 91, 255, 0.12);
+  padding: 0.4rem;
+  min-width: 220px;
+}
+.descarga-card-action .dropdown-item {
+  border-radius: 6px;
+  padding: 0.5rem 0.7rem;
+  font-size: 0.92rem;
+  color: #191919;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  text-decoration: none;
+  transition: background 120ms ease, color 120ms ease;
+}
+.descarga-card-action .dropdown-item:hover,
+.descarga-card-action .dropdown-item:focus {
+  background: rgba(64, 91, 255, 0.08);
+  color: #405BFF;
+}
+.descarga-card-action .dropdown-item .fa,
+.descarga-card-action .dropdown-item .fas,
+.descarga-card-action .dropdown-item .far {
+  color: #405BFF;
+  font-size: 0.95em;
+  width: 1.1em;
+  text-align: center;
+}
+.descarga-card-action .dropdown-item-size {
+  margin-left: auto;
+  color: #707070;
+  font-size: 0.82em;
+  font-weight: 500;
+}
+
+/* Aviso metodológico — card horizontal, treatment amber */
+.descarga-aviso {
+  border: 1px solid #FDE68A;
+  border-left: 4px solid #B45309;
+  border-radius: 12px;
+  background: #FFFBEB;
+  padding: 1.25rem 1.5rem;
+}
+.descarga-aviso-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #191919;
+  margin: 0 0 0.75rem 0;
+}
+.descarga-aviso-title .fa,
+.descarga-aviso-title .fas {
+  color: #B45309;
+}
+.descarga-aviso ul {
+  color: #404040;
+  line-height: 1.6;
+  padding-left: 1.25rem;
+  margin-bottom: 0.5rem;
+}
+.descarga-aviso ul li {
+  margin-bottom: 0.35rem;
 }


### PR DESCRIPTION
## v0.6.0

Primera release versionada de la app. Cierra issues #35, #32 y #40.

### Added

- Sección **Datos** en el sidebar con descarga del panel longitudinal
  completo en Parquet (22 MB) y CSV gzip (23 MB), diccionario de
  variables descargable y aviso de limitaciones metodológicas (#35).
- Generación de `data_output/panel_runtime.csv.gz` integrada al ETL
  mensual (`09-build_paneles_runtime.R`).
- Versionado de la app: `R/version.R`, `CHANGELOG.md` (Keep a Changelog
  + SemVer), versión visible en el footer del sidebar.
- Record de cambios a comunicar en `comunicaciones/cambios_a_comunicar.md`.

### Fixed

- Eje Y del line chart se recalcula al togglear series via legend
  interactiva (#32).
- Eje X del line chart roto por nested categories sin el plugin
  `grouped-categories`. Reemplazado por categorías planas + plotBands
  fantasma con label de año (#40).

### Changed

- Cache-busting de assets estáticos: `style.css`, `script.js` y
  `highlight.min.js` ahora incluyen `?v=<mtime>` en el href para
  invalidar cache del browser cuando el archivo cambia.

### Test plan

- [ ] Validar visual de la sección **Datos** (2 tarjetas + aviso) en staging.
- [ ] Probar las 3 descargas (Parquet, CSV gzip, diccionario CSV).
- [ ] Confirmar que GA4 registra eventos `dataset_download` con `{dataset, format}`.
- [ ] Verificar que el line chart recalcula eje Y al togglear series y que el eje X muestra dúos + año correctamente.
- [ ] Confirmar `v0.6.0` visible en el footer del sidebar.
- [ ] Smoke test post-deploy (curl + showLogs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)