### PR TITLE
v0.7.1: pipeline auto regenera paneles runtime (#48)

### DIFF
--- a/.github/workflows/update_eph_data.yml
+++ b/.github/workflows/update_eph_data.yml
@@ -66,6 +66,19 @@ jobs:
             echo "No hay períodos nuevos. Workflow termina sin cambios."
           fi
 
+      ### Regenerar los parquets de runtime (issue #48). Sin estos
+      ### pasos, los CSVs históricos quedan con el último trimestre
+      ### pero panel_runtime.parquet (intertrim) y panel_runtime_anual
+      ### .parquet siguen apuntando al trimestre viejo, generando un
+      ### drift entre lo que muestra Foto vs el resto del dashboard.
+      - name: Regenerar panel runtime intertrim
+        if: steps.check.outputs.has_new == 'true'
+        run: Rscript ETL/09-build_paneles_runtime.R
+
+      - name: Regenerar panel runtime anual
+        if: steps.check.outputs.has_new == 'true'
+        run: Rscript ETL/09b-build_paneles_runtime_anual.R
+
       - name: Limpiar archivo temporal antes del commit
         if: steps.check.outputs.has_new == 'true'
         run: rm -f .new_periods.txt
@@ -98,6 +111,8 @@ jobs:
             - `data_raw/df_eph.parquet` (microdato bruto)
             - `data_output/df_tasas_mt.parquet` (totales por trimestre)
             - `data_output/panel_cond_act_historico.csv` (paneles para line chart)
+            - `data_output/panel_runtime.parquet` + `.csv.gz` (runtime intertrim)
+            - `data_output/panel_runtime_anual.parquet` + `.csv.gz` (runtime anual, issue #44)
 
             ---
             *Generado por `.github/workflows/update_eph_data.yml`*
@@ -107,6 +122,18 @@ jobs:
             data_raw/df_eph.parquet
             data_output/df_tasas_mt.parquet
             data_output/panel_cond_act_historico.csv
+            data_output/panel_cat_ocup_historico.csv
+            data_output/panel_formalidad_historico.csv
+            data_output/panel_formalidad_ampliada_historico.csv
+            data_output/tasas_cond_act_historico.csv
+            data_output/tasas_cat_ocup_historico.csv
+            data_output/tasas_formalidad_historico.csv
+            data_output/tasas_formalidad_ampliada_historico.csv
+            data_output/calidad_panel_pct_historico.csv
+            data_output/panel_runtime.parquet
+            data_output/panel_runtime.csv.gz
+            data_output/panel_runtime_anual.parquet
+            data_output/panel_runtime_anual.csv.gz
 
       - name: Auto-merge del PR
         if: steps.cpr.outputs.pull-request-number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ versionado [SemVer](https://semver.org/lang/es/) adaptado a app web:
 
 ---
 
+## [0.7.1] · 2026-05-03
+
+### Changed
+
+- Pipeline mensual `update_eph_data.yml` ahora regenera
+  automáticamente los parquets runtime (intertrim + anual) cuando
+  hay un trimestre nuevo. Antes había que regenerarlos manualmente,
+  con riesgo de drift entre los CSVs históricos (auto) y los
+  parquets runtime (manuales). (#48)
+- `ETL/09-build_paneles_runtime.R` carga el microdato directamente
+  en lugar de depender de `01-extract.R` (que en runtime no lo
+  carga). Mismo patrón que `ETL/09b-build_paneles_runtime_anual.R`.
+- `add-paths` del PR auto incluye ahora todos los CSVs históricos +
+  los 4 parquets/csv.gz de runtime.
+
+---
+
 ## [0.7.0] · 2026-05-03
 
 ### Added

--- a/ETL/09-build_paneles_runtime.R
+++ b/ETL/09-build_paneles_runtime.R
@@ -21,10 +21,21 @@
 suppressPackageStartupMessages({
   source("ETL/00-libraries.R")
   source("ETL/99-functions.R")
-  source("ETL/01-extract.R")  ### carga df_eph_full como Arrow Table
 })
 
 cat("=== Pre-computando paneles runtime para shinyapps.io ===\n")
+
+### Cargar el microdato + sumar vars derivadas (formalidad,
+### formalidad_ampliada). 01-extract.R en runtime no carga el
+### microdato (solo el panel pre-computado), por eso lo levantamos
+### acá tal como hace 03-update_data.R y 09b. Issue #48.
+df_eph_full <- arrow::read_parquet("data_raw/df_eph.parquet") |>
+  agrega_vars_derivadas()
+
+### Enumerar periodos disponibles (ANO4, TRIMESTRE) en el microdato.
+periodos_disponibles <- df_eph_full |>
+  dplyr::distinct(ANO4, TRIMESTRE) |>
+  dplyr::arrange(ANO4, TRIMESTRE)
 
 ### Variables del microdato a propagar al panel armado. Superset de lo
 ### que cualquiera de los 3 análisis necesita: ESTADO + CAT_OCUP +

--- a/R/version.R
+++ b/R/version.R
@@ -10,4 +10,4 @@
 ###
 ### Se muestra en el sidebar footer (app.R) y queda disponible para
 ### eventuales evento GA4 con dimensión custom 'app_version'.
-APP_VERSION <- "0.7.0"
+APP_VERSION <- "0.7.1"


### PR DESCRIPTION
## v0.7.1 — Pipeline mensual auto-regenera paneles runtime

Cierra #48. Sprint A · primer paso.

### El problema

Hasta ahora, el workflow \`update_eph_data.yml\` corría
\`03-update_data.R\` que regeneraba los CSVs históricos cuando
INDEC publica un trimestre nuevo. Pero los parquets de runtime
(\`panel_runtime.parquet\` intertrim y \`panel_runtime_anual.parquet\`)
no se regeneraban automáticamente: había que hacerlo a mano y
commitear. Resultado: drift silencioso entre la **Foto** del
dashboard (lee del parquet runtime) y la **Película** + **Tasas**
(leen de CSVs históricos).

### El fix

Dos steps nuevos en el workflow después del \`03-update_data\`:

\`\`\`yaml
- name: Regenerar panel runtime intertrim
  if: steps.check.outputs.has_new == 'true'
  run: Rscript ETL/09-build_paneles_runtime.R

- name: Regenerar panel runtime anual
  if: steps.check.outputs.has_new == 'true'
  run: Rscript ETL/09b-build_paneles_runtime_anual.R
\`\`\`

Y los archivos van al \`add-paths\` del PR auto-generado para que
queden versionados.

### Refactor minor

\`ETL/09-build_paneles_runtime.R\` ahora carga el microdato
directamente (igual que \`09b\`) en lugar de depender de
\`01-extract.R\` (que en runtime no lo carga). Sin cambio de
comportamiento: el output es bit-idéntico.

### Test plan

- [ ] Trigger manual del workflow (\`workflow_dispatch\`) cuando no
      hay períodos nuevos: skip de los 2 nuevos steps (condición
      \`has_new == 'true'\`).
- [ ] Cuando entre el próximo trimestre real (probablemente fines de
      Q3 2026), validar que los parquets se regeneran y el PR auto
      los incluye.
- [ ] Smoke test post-deploy: la Foto del dashboard refleja el
      nuevo trimestre.
- [ ] v0.7.1 visible en sidebar footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)