### PR TITLE
hotfix v0.7.2: OOM en prod por panel anual cargado en RAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ versionado [SemVer](https://semver.org/lang/es/) adaptado a app web:
 
 ---
 
+## [0.7.2] · 2026-05-03 · HOTFIX
+
+### Fixed
+
+- **OOM en producción**: `panel_runtime_anual.parquet` ya no se carga
+  como Arrow Table al boot (en `ETL/01-extract.R`). Mantener dos
+  Tables abiertas simultáneamente excedía el budget de RAM del free
+  tier de shinyapps.io y disparaba `oom (out of memory)` justo
+  después de cargar bslib.
+- En modo Interanual, `armo_base_panel()` ahora abre el parquet
+  on-demand con filter pushdown y lo cierra cada llamada. Cuesta un
+  poco más de I/O por refresh (lectura de 16 MB) pero el footprint
+  de RAM al boot vuelve al nivel intertrim solo.
+- Al boot, los metadatos del panel anual (`periodos_disponibles_anual`,
+  `anios_disponibles_anual`) se derivan abriendo el parquet
+  temporalmente con `col_select` solo de las 4 columnas necesarias y
+  llamando `gc()` después.
+
+---
+
 ## [0.7.1] · 2026-05-03
 
 ### Changed

--- a/ETL/01-extract.R
+++ b/ETL/01-extract.R
@@ -27,17 +27,13 @@ df_panel_runtime <- arrow::read_parquet("data_output/panel_runtime.parquet",
 ### Panel runtime ANUAL (issue #44): mismo schema, distinto contenido.
 ### Parea cada vivienda con el MISMO trimestre del año siguiente
 ### (T1 año X ↔ T1 año X+1) en lugar de trimestres consecutivos.
-### Lo usa armo_base_panel(window = "anual"). Ver
-### ETL/09b-build_paneles_runtime_anual.R. Carga condicional: si el
-### script aún no se corrió, queda como NULL y la app sigue funcionando
-### en modo intertrimestral (default).
-path_panel_anual <- "data_output/panel_runtime_anual.parquet"
-df_panel_runtime_anual <- if (file.exists(path_panel_anual)) {
-  arrow::read_parquet(path_panel_anual, as_data_frame = FALSE)
-} else {
-  NULL
-}
-rm(path_panel_anual)
+###
+### IMPORTANTE: NO se carga al boot (issue #44 hotfix OOM). Mantener
+### dos arrow Tables abiertas simultáneamente (intertrim + anual)
+### supera el budget de RAM del free tier de shinyapps.io. En su lugar,
+### guardamos solo el path; armo_base_panel(window = "anual") abre el
+### parquet on-demand y lo cierra después de filtrar.
+PATH_PANEL_RUNTIME_ANUAL <- "data_output/panel_runtime_anual.parquet"
 
 ### Histórico pre-computado por data_generator.R
 df_cond_act <- arrow::read_csv_arrow("data_output/panel_cond_act_historico.csv")
@@ -130,21 +126,21 @@ anios_disponibles <- sort(unique(periodos_disponibles$ANO4))
 anio_max_disponible <- max(anios_disponibles)
 
 
-### Análogos para el panel ANUAL (issue #44). Si df_panel_runtime_anual
-### existe, derivamos los periodos donde hay dúo anual válido. Si no
-### existe (no se corrió aún el ETL 09b), devolvemos vectores vacíos y
-### la app sigue funcionando solo en modo trimestral.
-###
-### Análogo a periodos_disponibles intertrim: hacemos UNION de los t0
-### (anio_0, trim_0) y t1 (ANO4_t1, TRIMESTRE_t1) del panel anual, así
-### duos_disponibles_por_anio puede chequear que ambos extremos del
-### dúo existen.
-if (!is.null(df_panel_runtime_anual)) {
-  periodos_anual_t0 <- df_panel_runtime_anual |>
+### Análogos para el panel ANUAL (issue #44). Derivamos periodos
+### disponibles abriendo el parquet TEMPORALMENTE para extraer las
+### columnas anio_0/trim_0 + ANO4_t1/TRIMESTRE_t1, y lo cerramos.
+### NO mantenemos la Arrow Table abierta en memoria (hotfix OOM).
+if (file.exists(PATH_PANEL_RUNTIME_ANUAL)) {
+  ds_anual_tmp <- arrow::read_parquet(
+    PATH_PANEL_RUNTIME_ANUAL,
+    col_select = c("anio_0", "trim_0", "ANO4_t1", "TRIMESTRE_t1"),
+    as_data_frame = FALSE
+  )
+  periodos_anual_t0 <- ds_anual_tmp |>
     dplyr::distinct(anio_0, trim_0) |>
     dplyr::collect() |>
     dplyr::rename(ANO4 = anio_0, TRIMESTRE = trim_0)
-  periodos_anual_t1 <- df_panel_runtime_anual |>
+  periodos_anual_t1 <- ds_anual_tmp |>
     dplyr::distinct(ANO4_t1, TRIMESTRE_t1) |>
     dplyr::collect() |>
     dplyr::rename(ANO4 = ANO4_t1, TRIMESTRE = TRIMESTRE_t1)
@@ -159,7 +155,8 @@ if (!is.null(df_panel_runtime_anual)) {
   ### existen como t1 (ej. 2025 cuando 2026 todavía no llegó), y el
   ### usuario podría seleccionar 2025 como base sin que tenga dúo válido.
   anios_disponibles_anual <- sort(unique(periodos_anual_t0$ANO4))
-  rm(periodos_anual_t0, periodos_anual_t1)
+  rm(periodos_anual_t0, periodos_anual_t1, ds_anual_tmp)
+  invisible(gc(verbose = FALSE))
 } else {
   periodos_disponibles_anual <- periodos_disponibles[0, ]
   anios_disponibles_anual <- integer(0)

--- a/ETL/99-functions.R
+++ b/ETL/99-functions.R
@@ -245,33 +245,54 @@ armo_base_panel <- function(anio_0, trimestre_0, anio_1 = NULL, trimestre_1 = NU
                             window = "trimestral"){
 
   ### Modo runtime (default): usa el panel pre-computado.
-  ### Según `window` lee uno u otro parquet:
-  ###   - "trimestral" (default): df_panel_runtime (panel intertrim).
-  ###   - "anual": df_panel_runtime_anual (panel interanual T_n año X ↔
-  ###     T_n año X+1, issue #44).
-  ### Ambos parquets tienen schema idéntico, lo único que cambia es el
-  ### contenido (qué pareja de trimestres se pareó).
+  ###
+  ### Trimestral: lee df_panel_runtime (Arrow Table cargada al boot en
+  ### 01-extract.R como lazy view).
+  ###
+  ### Anual: lee data_output/panel_runtime_anual.parquet ON-DEMAND con
+  ### filter pushdown sobre (anio_0, trim_0). NO mantenemos esa Arrow
+  ### Table en memoria al boot porque sumar dos Tables abiertas excede
+  ### el budget de RAM del free tier de shinyapps.io (hotfix OOM,
+  ### parte de issue #44). Cada llamada a armo_base_panel(window =
+  ### "anual") abre el parquet, filtra, devuelve y deja que arrow
+  ### libere el handle.
   ###
   ### Modo legacy (cuando se pasa `df`): mantiene la lógica original con
   ### el microdato + organize_panels(). Lo usan los scripts ETL batch
   ### (05-build, 07-build, 08-build) que regeneran los CSV históricos.
   if (is.null(df)) {
-    nombre_runtime <- switch(window,
-      "trimestral" = "df_panel_runtime",
-      "anual"      = "df_panel_runtime_anual",
+    if (window == "trimestral") {
+      if (!exists("df_panel_runtime", envir = .GlobalEnv)) {
+        stop("df_panel_runtime no disponible. Ejecutar ETL/01-extract.R.")
+      }
+      return(
+        get("df_panel_runtime", envir = .GlobalEnv) |>
+          dplyr::filter(anio_0 == !!anio_0, trim_0 == !!trimestre_0) |>
+          dplyr::select(-anio_0, -trim_0) |>
+          dplyr::collect()
+      )
+    } else if (window == "anual") {
+      path <- if (exists("PATH_PANEL_RUNTIME_ANUAL", envir = .GlobalEnv)) {
+        get("PATH_PANEL_RUNTIME_ANUAL", envir = .GlobalEnv)
+      } else {
+        "data_output/panel_runtime_anual.parquet"
+      }
+      if (!file.exists(path)) {
+        stop("panel_runtime_anual.parquet no encontrado en ", path,
+             ". Correr ETL/09b-build_paneles_runtime_anual.R.")
+      }
+      ### read_parquet con as_data_frame = FALSE devuelve Arrow Table.
+      ### El filter de dplyr sobre Arrow hace pushdown: solo lee las
+      ### filas que matchean (anio_0, trim_0) del row group.
+      return(
+        arrow::read_parquet(path, as_data_frame = FALSE) |>
+          dplyr::filter(anio_0 == !!anio_0, trim_0 == !!trimestre_0) |>
+          dplyr::select(-anio_0, -trim_0) |>
+          dplyr::collect()
+      )
+    } else {
       stop("window debe ser 'trimestral' o 'anual', recibido: ", window)
-    )
-    if (!exists(nombre_runtime, envir = .GlobalEnv) ||
-        is.null(get(nombre_runtime, envir = .GlobalEnv))) {
-      stop(nombre_runtime, " no disponible. Ejecutar ETL/01-extract.R ",
-           "y verificar que el parquet exista en data_output/.")
     }
-    return(
-      get(nombre_runtime, envir = .GlobalEnv) |>
-        dplyr::filter(anio_0 == !!anio_0, trim_0 == !!trimestre_0) |>
-        dplyr::select(-anio_0, -trim_0) |>
-        dplyr::collect()
-    )
   }
 
   ### Modo legacy: filtra el microdato y arma el panel via organize_panels().

--- a/R/version.R
+++ b/R/version.R
@@ -10,4 +10,4 @@
 ###
 ### Se muestra en el sidebar footer (app.R) y queda disponible para
 ### eventuales evento GA4 con dimensión custom 'app_version'.
-APP_VERSION <- "0.7.1"
+APP_VERSION <- "0.7.2"


### PR DESCRIPTION
## 🚨 Hotfix urgente

La app en prod tira \`signal: killed\` al boot. Logs de shinyapps.io confirman \`Container event: oom (out of memory)\` justo después de cargar bslib.

## Causa raíz

El v0.7.0 introdujo \`panel_runtime_anual.parquet\` (16 MB) que se cargaba como Arrow Table **además del** intertrim (22 MB) en \`ETL/01-extract.R\`. Mantener 2 Tables abiertas simultáneamente excede el budget de RAM del free tier (~1 GB).

## Fix

- **01-extract.R**: el parquet anual ya no se mantiene en memoria. Solo se abre temporalmente con \`col_select\` de las 4 columnas necesarias (anio_0, trim_0, ANO4_t1, TRIMESTRE_t1) para derivar \`periodos_disponibles_anual\` y \`anios_disponibles_anual\`. Después se hace \`rm()\` + \`gc()\`.
- **armo_base_panel(window = \"anual\")**: abre el parquet on-demand con filter pushdown sobre (anio_0, trim_0), \`collect()\`, y devuelve. Cada llamada relee el parquet (16 MB de I/O) pero el RAM peak vuelve al nivel pre-#44.

## Trade-off

Modo anual cuesta ~50-100 ms extra por refresh de Foto (lectura con pushdown) vs filtrado puro en memoria. Imperceptible en uso real.

## Validación

- [x] Smoke test local: \`HTTP 200\` con app cargada (sin OOM).
- [ ] Deploy a staging y verificar boot OK.
- [ ] Validar Foto en modo Interanual sigue funcionando (lectura on-demand).
- [ ] Promover a master.

## Bump

v0.7.2 (patch hotfix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)