### PR TITLE
Promote staging → master: v0.7.1 + v0.7.2 + v0.7.3 + ROADMAP

### DIFF
--- a/.github/workflows/update_eph_data.yml
+++ b/.github/workflows/update_eph_data.yml
@@ -66,6 +66,19 @@ jobs:
             echo "No hay períodos nuevos. Workflow termina sin cambios."
           fi
 
+      ### Regenerar los parquets de runtime (issue #48). Sin estos
+      ### pasos, los CSVs históricos quedan con el último trimestre
+      ### pero panel_runtime.parquet (intertrim) y panel_runtime_anual
+      ### .parquet siguen apuntando al trimestre viejo, generando un
+      ### drift entre lo que muestra Foto vs el resto del dashboard.
+      - name: Regenerar panel runtime intertrim
+        if: steps.check.outputs.has_new == 'true'
+        run: Rscript ETL/09-build_paneles_runtime.R
+
+      - name: Regenerar panel runtime anual
+        if: steps.check.outputs.has_new == 'true'
+        run: Rscript ETL/09b-build_paneles_runtime_anual.R
+
       - name: Limpiar archivo temporal antes del commit
         if: steps.check.outputs.has_new == 'true'
         run: rm -f .new_periods.txt
@@ -98,6 +111,8 @@ jobs:
             - `data_raw/df_eph.parquet` (microdato bruto)
             - `data_output/df_tasas_mt.parquet` (totales por trimestre)
             - `data_output/panel_cond_act_historico.csv` (paneles para line chart)
+            - `data_output/panel_runtime.parquet` + `.csv.gz` (runtime intertrim)
+            - `data_output/panel_runtime_anual.parquet` + `.csv.gz` (runtime anual, issue #44)
 
             ---
             *Generado por `.github/workflows/update_eph_data.yml`*
@@ -107,6 +122,18 @@ jobs:
             data_raw/df_eph.parquet
             data_output/df_tasas_mt.parquet
             data_output/panel_cond_act_historico.csv
+            data_output/panel_cat_ocup_historico.csv
+            data_output/panel_formalidad_historico.csv
+            data_output/panel_formalidad_ampliada_historico.csv
+            data_output/tasas_cond_act_historico.csv
+            data_output/tasas_cat_ocup_historico.csv
+            data_output/tasas_formalidad_historico.csv
+            data_output/tasas_formalidad_ampliada_historico.csv
+            data_output/calidad_panel_pct_historico.csv
+            data_output/panel_runtime.parquet
+            data_output/panel_runtime.csv.gz
+            data_output/panel_runtime_anual.parquet
+            data_output/panel_runtime_anual.csv.gz
 
       - name: Auto-merge del PR
         if: steps.cpr.outputs.pull-request-number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ versionado [SemVer](https://semver.org/lang/es/) adaptado a app web:
 
 ---
 
+## [0.7.1] · 2026-05-03
+
+### Changed
+
+- Pipeline mensual `update_eph_data.yml` ahora regenera
+  automáticamente los parquets runtime (intertrim + anual) cuando
+  hay un trimestre nuevo. Antes había que regenerarlos manualmente,
+  con riesgo de drift entre los CSVs históricos (auto) y los
+  parquets runtime (manuales). (#48)
+- `ETL/09-build_paneles_runtime.R` carga el microdato directamente
+  en lugar de depender de `01-extract.R` (que en runtime no lo
+  carga). Mismo patrón que `ETL/09b-build_paneles_runtime_anual.R`.
+- `add-paths` del PR auto incluye ahora todos los CSVs históricos +
+  los 4 parquets/csv.gz de runtime.
+
+---
+
 ## [0.7.0] · 2026-05-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ versionado [SemVer](https://semver.org/lang/es/) adaptado a app web:
 
 ---
 
+## [0.7.3] · 2026-05-03 · HOTFIX (continuación)
+
+### Fixed
+
+- **OOM al togglear a modo Interanual**. El v0.7.2 evitaba el OOM al
+  boot pero seguía rompiendo cuando el usuario cambiaba a Interanual.
+  Cada llamada a `armo_base_panel(window = "anual")` desde un módulo
+  hacía `arrow::read_parquet(path, as_data_frame = FALSE)` que carga
+  el parquet entero (~16 MB) como Arrow Table en memoria. En Foto hay
+  3-5 llamadas en cascada (sankey + matriz + 3 tasas + delta año
+  anterior), sumando ~80 MB que arrow no liberaba a tiempo.
+- **Reemplazado por `arrow::open_dataset()`**, que es realmente lazy:
+  solo lee el footer del parquet + los row groups que matchean al
+  filter. Footprint mínimo y predictible a través de múltiples
+  llamadas.
+- Mismo cambio aplicado a `01-extract.R` para los metadatos del panel
+  anual al boot.
+
+---
+
 ## [0.7.2] · 2026-05-03 · HOTFIX
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ versionado [SemVer](https://semver.org/lang/es/) adaptado a app web:
 
 ---
 
+## [0.7.2] · 2026-05-03 · HOTFIX
+
+### Fixed
+
+- **OOM en producción**: `panel_runtime_anual.parquet` ya no se carga
+  como Arrow Table al boot (en `ETL/01-extract.R`). Mantener dos
+  Tables abiertas simultáneamente excedía el budget de RAM del free
+  tier de shinyapps.io y disparaba `oom (out of memory)` justo
+  después de cargar bslib.
+- En modo Interanual, `armo_base_panel()` ahora abre el parquet
+  on-demand con filter pushdown y lo cierra cada llamada. Cuesta un
+  poco más de I/O por refresh (lectura de 16 MB) pero el footprint
+  de RAM al boot vuelve al nivel intertrim solo.
+- Al boot, los metadatos del panel anual (`periodos_disponibles_anual`,
+  `anios_disponibles_anual`) se derivan abriendo el parquet
+  temporalmente con `col_select` solo de las 4 columnas necesarias y
+  llamando `gc()` después.
+
+---
+
 ## [0.7.1] · 2026-05-03
 
 ### Changed

--- a/ETL/01-extract.R
+++ b/ETL/01-extract.R
@@ -27,17 +27,13 @@ df_panel_runtime <- arrow::read_parquet("data_output/panel_runtime.parquet",
 ### Panel runtime ANUAL (issue #44): mismo schema, distinto contenido.
 ### Parea cada vivienda con el MISMO trimestre del año siguiente
 ### (T1 año X ↔ T1 año X+1) en lugar de trimestres consecutivos.
-### Lo usa armo_base_panel(window = "anual"). Ver
-### ETL/09b-build_paneles_runtime_anual.R. Carga condicional: si el
-### script aún no se corrió, queda como NULL y la app sigue funcionando
-### en modo intertrimestral (default).
-path_panel_anual <- "data_output/panel_runtime_anual.parquet"
-df_panel_runtime_anual <- if (file.exists(path_panel_anual)) {
-  arrow::read_parquet(path_panel_anual, as_data_frame = FALSE)
-} else {
-  NULL
-}
-rm(path_panel_anual)
+###
+### IMPORTANTE: NO se carga al boot (issue #44 hotfix OOM). Mantener
+### dos arrow Tables abiertas simultáneamente (intertrim + anual)
+### supera el budget de RAM del free tier de shinyapps.io. En su lugar,
+### guardamos solo el path; armo_base_panel(window = "anual") abre el
+### parquet on-demand y lo cierra después de filtrar.
+PATH_PANEL_RUNTIME_ANUAL <- "data_output/panel_runtime_anual.parquet"
 
 ### Histórico pre-computado por data_generator.R
 df_cond_act <- arrow::read_csv_arrow("data_output/panel_cond_act_historico.csv")
@@ -130,21 +126,21 @@ anios_disponibles <- sort(unique(periodos_disponibles$ANO4))
 anio_max_disponible <- max(anios_disponibles)
 
 
-### Análogos para el panel ANUAL (issue #44). Si df_panel_runtime_anual
-### existe, derivamos los periodos donde hay dúo anual válido. Si no
-### existe (no se corrió aún el ETL 09b), devolvemos vectores vacíos y
-### la app sigue funcionando solo en modo trimestral.
-###
-### Análogo a periodos_disponibles intertrim: hacemos UNION de los t0
-### (anio_0, trim_0) y t1 (ANO4_t1, TRIMESTRE_t1) del panel anual, así
-### duos_disponibles_por_anio puede chequear que ambos extremos del
-### dúo existen.
-if (!is.null(df_panel_runtime_anual)) {
-  periodos_anual_t0 <- df_panel_runtime_anual |>
+### Análogos para el panel ANUAL (issue #44). Derivamos periodos
+### disponibles abriendo el parquet TEMPORALMENTE para extraer las
+### columnas anio_0/trim_0 + ANO4_t1/TRIMESTRE_t1, y lo cerramos.
+### NO mantenemos la Arrow Table abierta en memoria (hotfix OOM).
+if (file.exists(PATH_PANEL_RUNTIME_ANUAL)) {
+  ds_anual_tmp <- arrow::read_parquet(
+    PATH_PANEL_RUNTIME_ANUAL,
+    col_select = c("anio_0", "trim_0", "ANO4_t1", "TRIMESTRE_t1"),
+    as_data_frame = FALSE
+  )
+  periodos_anual_t0 <- ds_anual_tmp |>
     dplyr::distinct(anio_0, trim_0) |>
     dplyr::collect() |>
     dplyr::rename(ANO4 = anio_0, TRIMESTRE = trim_0)
-  periodos_anual_t1 <- df_panel_runtime_anual |>
+  periodos_anual_t1 <- ds_anual_tmp |>
     dplyr::distinct(ANO4_t1, TRIMESTRE_t1) |>
     dplyr::collect() |>
     dplyr::rename(ANO4 = ANO4_t1, TRIMESTRE = TRIMESTRE_t1)
@@ -159,7 +155,8 @@ if (!is.null(df_panel_runtime_anual)) {
   ### existen como t1 (ej. 2025 cuando 2026 todavía no llegó), y el
   ### usuario podría seleccionar 2025 como base sin que tenga dúo válido.
   anios_disponibles_anual <- sort(unique(periodos_anual_t0$ANO4))
-  rm(periodos_anual_t0, periodos_anual_t1)
+  rm(periodos_anual_t0, periodos_anual_t1, ds_anual_tmp)
+  invisible(gc(verbose = FALSE))
 } else {
   periodos_disponibles_anual <- periodos_disponibles[0, ]
   anios_disponibles_anual <- integer(0)

--- a/ETL/01-extract.R
+++ b/ETL/01-extract.R
@@ -131,17 +131,19 @@ anio_max_disponible <- max(anios_disponibles)
 ### columnas anio_0/trim_0 + ANO4_t1/TRIMESTRE_t1, y lo cerramos.
 ### NO mantenemos la Arrow Table abierta en memoria (hotfix OOM).
 if (file.exists(PATH_PANEL_RUNTIME_ANUAL)) {
-  ds_anual_tmp <- arrow::read_parquet(
-    PATH_PANEL_RUNTIME_ANUAL,
-    col_select = c("anio_0", "trim_0", "ANO4_t1", "TRIMESTRE_t1"),
-    as_data_frame = FALSE
-  )
+  ### open_dataset es lazy real (solo lee footer + row groups
+  ### necesarios). Mucho más liviano que read_parquet (que carga
+  ### todo el archivo a memoria). Hotfix v0.7.3 sobre OOM al
+  ### togglear, mismo patrón que armo_base_panel(window = "anual").
+  ds_anual_tmp <- arrow::open_dataset(PATH_PANEL_RUNTIME_ANUAL)
   periodos_anual_t0 <- ds_anual_tmp |>
-    dplyr::distinct(anio_0, trim_0) |>
+    dplyr::select(anio_0, trim_0) |>
+    dplyr::distinct() |>
     dplyr::collect() |>
     dplyr::rename(ANO4 = anio_0, TRIMESTRE = trim_0)
   periodos_anual_t1 <- ds_anual_tmp |>
-    dplyr::distinct(ANO4_t1, TRIMESTRE_t1) |>
+    dplyr::select(ANO4_t1, TRIMESTRE_t1) |>
+    dplyr::distinct() |>
     dplyr::collect() |>
     dplyr::rename(ANO4 = ANO4_t1, TRIMESTRE = TRIMESTRE_t1)
   ### periodos_disponibles_anual: union (t0+t1) para validar dúos en

--- a/ETL/09-build_paneles_runtime.R
+++ b/ETL/09-build_paneles_runtime.R
@@ -21,10 +21,21 @@
 suppressPackageStartupMessages({
   source("ETL/00-libraries.R")
   source("ETL/99-functions.R")
-  source("ETL/01-extract.R")  ### carga df_eph_full como Arrow Table
 })
 
 cat("=== Pre-computando paneles runtime para shinyapps.io ===\n")
+
+### Cargar el microdato + sumar vars derivadas (formalidad,
+### formalidad_ampliada). 01-extract.R en runtime no carga el
+### microdato (solo el panel pre-computado), por eso lo levantamos
+### acá tal como hace 03-update_data.R y 09b. Issue #48.
+df_eph_full <- arrow::read_parquet("data_raw/df_eph.parquet") |>
+  agrega_vars_derivadas()
+
+### Enumerar periodos disponibles (ANO4, TRIMESTRE) en el microdato.
+periodos_disponibles <- df_eph_full |>
+  dplyr::distinct(ANO4, TRIMESTRE) |>
+  dplyr::arrange(ANO4, TRIMESTRE)
 
 ### Variables del microdato a propagar al panel armado. Superset de lo
 ### que cualquiera de los 3 análisis necesita: ESTADO + CAT_OCUP +

--- a/ETL/99-functions.R
+++ b/ETL/99-functions.R
@@ -245,33 +245,54 @@ armo_base_panel <- function(anio_0, trimestre_0, anio_1 = NULL, trimestre_1 = NU
                             window = "trimestral"){
 
   ### Modo runtime (default): usa el panel pre-computado.
-  ### Según `window` lee uno u otro parquet:
-  ###   - "trimestral" (default): df_panel_runtime (panel intertrim).
-  ###   - "anual": df_panel_runtime_anual (panel interanual T_n año X ↔
-  ###     T_n año X+1, issue #44).
-  ### Ambos parquets tienen schema idéntico, lo único que cambia es el
-  ### contenido (qué pareja de trimestres se pareó).
+  ###
+  ### Trimestral: lee df_panel_runtime (Arrow Table cargada al boot en
+  ### 01-extract.R como lazy view).
+  ###
+  ### Anual: lee data_output/panel_runtime_anual.parquet ON-DEMAND con
+  ### filter pushdown sobre (anio_0, trim_0). NO mantenemos esa Arrow
+  ### Table en memoria al boot porque sumar dos Tables abiertas excede
+  ### el budget de RAM del free tier de shinyapps.io (hotfix OOM,
+  ### parte de issue #44). Cada llamada a armo_base_panel(window =
+  ### "anual") abre el parquet, filtra, devuelve y deja que arrow
+  ### libere el handle.
   ###
   ### Modo legacy (cuando se pasa `df`): mantiene la lógica original con
   ### el microdato + organize_panels(). Lo usan los scripts ETL batch
   ### (05-build, 07-build, 08-build) que regeneran los CSV históricos.
   if (is.null(df)) {
-    nombre_runtime <- switch(window,
-      "trimestral" = "df_panel_runtime",
-      "anual"      = "df_panel_runtime_anual",
+    if (window == "trimestral") {
+      if (!exists("df_panel_runtime", envir = .GlobalEnv)) {
+        stop("df_panel_runtime no disponible. Ejecutar ETL/01-extract.R.")
+      }
+      return(
+        get("df_panel_runtime", envir = .GlobalEnv) |>
+          dplyr::filter(anio_0 == !!anio_0, trim_0 == !!trimestre_0) |>
+          dplyr::select(-anio_0, -trim_0) |>
+          dplyr::collect()
+      )
+    } else if (window == "anual") {
+      path <- if (exists("PATH_PANEL_RUNTIME_ANUAL", envir = .GlobalEnv)) {
+        get("PATH_PANEL_RUNTIME_ANUAL", envir = .GlobalEnv)
+      } else {
+        "data_output/panel_runtime_anual.parquet"
+      }
+      if (!file.exists(path)) {
+        stop("panel_runtime_anual.parquet no encontrado en ", path,
+             ". Correr ETL/09b-build_paneles_runtime_anual.R.")
+      }
+      ### read_parquet con as_data_frame = FALSE devuelve Arrow Table.
+      ### El filter de dplyr sobre Arrow hace pushdown: solo lee las
+      ### filas que matchean (anio_0, trim_0) del row group.
+      return(
+        arrow::read_parquet(path, as_data_frame = FALSE) |>
+          dplyr::filter(anio_0 == !!anio_0, trim_0 == !!trimestre_0) |>
+          dplyr::select(-anio_0, -trim_0) |>
+          dplyr::collect()
+      )
+    } else {
       stop("window debe ser 'trimestral' o 'anual', recibido: ", window)
-    )
-    if (!exists(nombre_runtime, envir = .GlobalEnv) ||
-        is.null(get(nombre_runtime, envir = .GlobalEnv))) {
-      stop(nombre_runtime, " no disponible. Ejecutar ETL/01-extract.R ",
-           "y verificar que el parquet exista en data_output/.")
     }
-    return(
-      get(nombre_runtime, envir = .GlobalEnv) |>
-        dplyr::filter(anio_0 == !!anio_0, trim_0 == !!trimestre_0) |>
-        dplyr::select(-anio_0, -trim_0) |>
-        dplyr::collect()
-    )
   }
 
   ### Modo legacy: filtra el microdato y arma el panel via organize_panels().

--- a/ETL/99-functions.R
+++ b/ETL/99-functions.R
@@ -281,11 +281,18 @@ armo_base_panel <- function(anio_0, trimestre_0, anio_1 = NULL, trimestre_1 = NU
         stop("panel_runtime_anual.parquet no encontrado en ", path,
              ". Correr ETL/09b-build_paneles_runtime_anual.R.")
       }
-      ### read_parquet con as_data_frame = FALSE devuelve Arrow Table.
-      ### El filter de dplyr sobre Arrow hace pushdown: solo lee las
-      ### filas que matchean (anio_0, trim_0) del row group.
+      ### IMPORTANTE: usar arrow::open_dataset() en lugar de read_parquet().
+      ### read_parquet (incluso con as_data_frame = FALSE) carga el archivo
+      ### entero a una Arrow Table en memoria; cada llamada a este
+      ### armo_base_panel desde un módulo (sankey, matriz, tasas, delta
+      ### anio anterior) sumaba ~16 MB que arrow no liberaba a tiempo,
+      ### disparando OOM en el free tier al togglear modo anual.
+      ###
+      ### open_dataset es realmente lazy: solo lee el footer y los row
+      ### groups que matchean al filter. Footprint mínimo, predictible
+      ### a través de múltiples llamadas. Hotfix v0.7.3.
       return(
-        arrow::read_parquet(path, as_data_frame = FALSE) |>
+        arrow::open_dataset(path) |>
           dplyr::filter(anio_0 == !!anio_0, trim_0 == !!trimestre_0) |>
           dplyr::select(-anio_0, -trim_0) |>
           dplyr::collect()

--- a/R/version.R
+++ b/R/version.R
@@ -10,4 +10,4 @@
 ###
 ### Se muestra en el sidebar footer (app.R) y queda disponible para
 ### eventuales evento GA4 con dimensión custom 'app_version'.
-APP_VERSION <- "0.7.1"
+APP_VERSION <- "0.7.2"

--- a/R/version.R
+++ b/R/version.R
@@ -10,4 +10,4 @@
 ###
 ### Se muestra en el sidebar footer (app.R) y queda disponible para
 ### eventuales evento GA4 con dimensión custom 'app_version'.
-APP_VERSION <- "0.7.0"
+APP_VERSION <- "0.7.1"

--- a/R/version.R
+++ b/R/version.R
@@ -10,4 +10,4 @@
 ###
 ### Se muestra en el sidebar footer (app.R) y queda disponible para
 ### eventuales evento GA4 con dimensión custom 'app_version'.
-APP_VERSION <- "0.7.2"
+APP_VERSION <- "0.7.3"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,116 @@
+# Roadmap — shiny_eph_panel
+
+> Plan de prioridades vivo. Se actualiza al cerrar cada sprint.
+> Última revisión: **2026-05-03**.
+
+---
+
+## Versión actual
+
+**v0.7.0** — Tipo de dúo intertrim/interanual (Fase 1, Foto). Ver
+[CHANGELOG.md](CHANGELOG.md) para el detalle.
+
+---
+
+## Sprint A · Cerrar feature Tipo de dúo (#44 completo)
+
+**Objetivo:** terminar de habilitar el toggle Interanual en toda la
+app. Hoy solo Foto soporta Interanual; Película y Tasas muestran un
+banner azul "no soportado".
+
+**Orden:**
+
+1. **#48** Pipeline mensual auto-regenera parquets runtime · ~1 hr.
+   Sin esto, cada update mensual deja CSVs nuevos y parquets viejos.
+2. **#46** Fase 2: Película + Tasas en modo Interanual · ~2-3 hs.
+   Genera CSVs anuales pre-calculados, conecta los módulos, quita
+   el banner.
+3. **#47** Fase 3: Calidad + Datos descargables en modo Interanual ·
+   ~1-2 hs. Cierra el feature visual end-to-end.
+
+**Por qué este orden:** #48 antes de #46 porque automatizar la
+regeneración del panel anual es prerequisito para que los CSVs
+anuales no entren en drift cuando se cargue un trimestre nuevo.
+
+---
+
+## Sprint B · Calidad técnica
+
+**Objetivo:** robustez y limpieza después de meter Tipo de dúo
+completo.
+
+- **#45** Validación ETL paneles intertrim + anual · ~2 hs.
+  Schema, cobertura, tamaño, distribuciones, consistencia.
+- **#39** Pasada integral (parcial) · ~3-5 hs.
+  Anti-patterns dplyr/purrr, CSS muerto, dependencias no usadas.
+  Diferimos lo grande (refactor mayor) que se cubre en Sprint C.
+
+**Cuándo:** después de Sprint A. Ya tendremos ~1.5 meses de GA4
+acumulado para guiar optimizaciones con datos reales.
+
+---
+
+## Sprint C · Refactor habilitante
+
+**Objetivo:** abaratar las features mayores que vienen.
+
+- **#12** Refactor a `mod_analisis()` genérico · ~3-4 hs.
+  Los 3 módulos (cond_act, cat_ocup, formalidad) comparten ~80% del
+  código. Después del refactor, sumar un 4° módulo (pobreza, #30) o
+  filtros sociodemográficos (#29) requiere modificar 1 lugar en
+  lugar de 3.
+
+**Cuándo:** antes de #29 y #30 sí o sí.
+
+---
+
+## Sprint D · Decisión metodológica
+
+- **#13** Formal/Informal "tiene descuento jubilatorio" · ~1-2 hs.
+  Bloqueado por 5 preguntas metodológicas que requieren input de
+  Pablo (universo, no-asalariados, NA, caption, regen histórico).
+
+**Cuándo:** una sesión enfocada cuando Pablo tenga tiempo de revisar
+las preguntas. No es bloqueante para nada más.
+
+---
+
+## Sprint E · Features mayores (sprints dedicados)
+
+### #29 Filtros sociodemográficos · ~4-6 hs
+
+Sumar filtros por sexo, grupo etario, nivel educativo, jefatura de
+hogar, presencia de menores, aglomerado/región a las matrices y
+tasas. Habilita preguntas como *"¿quién persiste en la informalidad?"*.
+
+**Pre-requisito:** #12 (refactor) para que el cambio sea uno solo.
+
+### #30 Pobreza/indigencia · ~8-12 hs
+
+Cuarto módulo: transiciones de pobreza e indigencia entre dos puntos
+del panel. Dataset propio (canastas CBA/CBT mensuales por aglomerado,
+deflactor IPC). Diferencial fuerte vs reportes oficiales de INDEC.
+
+**Pre-requisito:** #12 (refactor). Sprint dedicado.
+
+---
+
+## Backlog wishlist
+
+| # | Notas |
+|---|---|
+| **#5** Chatbot ellmer + Gemini | Spike exploratorio. Cuando haya energía y costo justificable |
+| **#42** Migrar Glosario/Definiciones a `.md`/`.qmd` | Mejora de mantenibilidad. Solo cuando crezca el contenido |
+| **#43** Extender glosario con variables nuevas | Convención: aplicar al cerrar cada feature con vars nuevas (#29, #30) |
+
+---
+
+## Cómo se mantiene este documento
+
+- Al cerrar un sprint, mover los issues completados a la sección
+  `## Sprints completados` (a crear cuando suceda) con el rango de
+  fechas.
+- Al re-priorizar, actualizar el orden y agregar nota de cuándo y
+  por qué.
+- Si entra un issue urgente fuera de plan (bug crítico, requerimiento
+  externo), evaluar si interrumpe Sprint actual o se difiere.


### PR DESCRIPTION
## Promoción staging → master · 8 commits

Master quedó atrás de staging después de varios PRs de feature + hotfix. Este PR sincroniza prod con todos los cambios validados en staging.

### Versiones que entran

#### v0.7.1 (#48 — Pipeline auto regen parquets)
- Workflow mensual ahora regenera \`panel_runtime.parquet\` y \`panel_runtime_anual.parquet\` cuando entran trimestres nuevos. Evita drift entre CSVs históricos (auto) y parquets runtime (antes manuales).
- Refactor \`ETL/09-build_paneles_runtime.R\` para correr standalone.

#### v0.7.2 (#53 — Hotfix OOM al boot)
- \`panel_runtime_anual.parquet\` ya no se carga como Arrow Table al boot (causaba OOM al cargar bslib). Solo se extraen metadatos temporalmente.
- \`armo_base_panel(window = "anual")\` abre el parquet on-demand.

#### v0.7.3 (#55 — Hotfix OOM al togglear)
- Reemplazado \`arrow::read_parquet(as_data_frame = FALSE)\` por \`arrow::open_dataset()\` en armo_base_panel anual y en metadatos de boot. \`open_dataset\` es realmente lazy; \`read_parquet\` cargaba el archivo entero en cada llamada y arrow no liberaba a tiempo → OOM tras 30s en Foto modo anual.

#### chore (#51 — ROADMAP)
- Plan de prioridades vivo en \`ROADMAP.md\`.

### Test plan post-merge

- [ ] Deploy automático a prod (\`shiny_eph_panel\`) tras el merge.
- [ ] Smoke test: prod arranca sin OOM al boot.
- [ ] Toggle a Interanual: Foto carga sin caer.
- [ ] Verificar v0.7.3 en sidebar footer.
- [ ] Tags de git: v0.7.2, v0.7.3 (pendientes).

### Sigue

Después de este merge, PR #54 (v0.8.0 Película + Tasas anual) requerirá rebase sobre staging actualizado para mergear sin conflictos. El feature heredará automáticamente el fix \`open_dataset\` para todas las llamadas anuales en cascada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)