### PR TITLE
Promote staging → master: v0.8.1 (fix selector Película)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ versionado [SemVer](https://semver.org/lang/es/) adaptado a app web:
 
 ---
 
+## [0.8.1] · 2026-05-04
+
+### Fixed
+
+- Selector "Trimestres" en sub-tab **Película** no se actualizaba al
+  togglear modo Interanual (seguía mostrando `1-2 / 2-3 / 3-4 / 4-1`
+  en lugar de `T1 / T2 / T3 / T4`). En v0.8.0 el observer del
+  `tipo_duo` solo updateaba el selector `tasas_duo` (Tasas), faltaba
+  hacer lo mismo con el selector `duo` (Película) en los 3 módulos
+  (cond_act, cat_ocup, formalidad).
+
+---
+
 ## [0.8.0] · 2026-05-03
 
 ### Added

--- a/R/mod_analisis_cat_ocup.R
+++ b/R/mod_analisis_cat_ocup.R
@@ -297,6 +297,10 @@ mod_cat_ocup_server <- function(id, tipo_duo = shiny::reactive("trimestral")) {
       updateSelectInput(session, "tasas_duo",
                         choices = choices_nuevos,
                         selected = "todos")
+      ### Mismo selector "Trimestres" en sub-tab Película (input `duo`).
+      updateSelectInput(session, "duo",
+                        choices = choices_nuevos,
+                        selected = "todos")
     })
 
     ### Cuando cambia el modo, actualizar el selector de año.

--- a/R/mod_analisis_cond_act.R
+++ b/R/mod_analisis_cond_act.R
@@ -384,6 +384,10 @@ mod_cond_act_server <- function(id, tipo_duo = shiny::reactive("trimestral")) {
       updateSelectInput(session, "tasas_duo",
                         choices = choices_nuevos,
                         selected = "todos")
+      ### Mismo selector "Trimestres" en sub-tab Película (input `duo`).
+      updateSelectInput(session, "duo",
+                        choices = choices_nuevos,
+                        selected = "todos")
     })
 
     ### Cuando cambia el modo, actualizar el selector de año para limitar

--- a/R/mod_analisis_formalidad.R
+++ b/R/mod_analisis_formalidad.R
@@ -285,6 +285,10 @@ mod_formalidad_server <- function(id, tipo_duo = shiny::reactive("trimestral")) 
       updateSelectInput(session, "tasas_duo",
                         choices = choices_nuevos,
                         selected = "todos")
+      ### Mismo selector "Trimestres" en sub-tab Película (input `duo`).
+      updateSelectInput(session, "duo",
+                        choices = choices_nuevos,
+                        selected = "todos")
     })
 
     etiqueta_plural <- function(cat) {

--- a/R/version.R
+++ b/R/version.R
@@ -10,4 +10,4 @@
 ###
 ### Se muestra en el sidebar footer (app.R) y queda disponible para
 ### eventuales evento GA4 con dimensión custom 'app_version'.
-APP_VERSION <- "0.8.0"
+APP_VERSION <- "0.8.1"


### PR DESCRIPTION
Promueve v0.8.1 a prod. Fix del selector "Trimestres" en sub-tab Película (al togglear Interanual seguía mostrando 1-2/2-3/3-4/4-1 en lugar de T1/T2/T3/T4). Aplica a los 3 análisis (cond_act, cat_ocup, formalidad). Test plan post-deploy: footer v0.8.1 + selector Trimestres adapta correctamente al modo en Película.