### PR TITLE
test: Sprint test-2 — server logic + armo_base_panel anual

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,14 @@ versionado [SemVer](https://semver.org/lang/es/) adaptado a app web:
 - Sprint test-1 batch 3: tests para `arma_matriz_transicion`,
   `build_tasas_historico`, `regenerar_calidad_panel`, `formato_delta`,
   `sankey_label_legible`, `sankey_nodes_orden`. Suite de testthat pasa
-  de 79 a **149 tests verde**. Cobertura aproximada del Sprint test-1
-  cerrada salvo `armo_base_panel` legacy (movido a Sprint test-2 para
-  combinarlo con cobertura de modo runtime via `testServer`).
+  de 79 a 149 tests verde.
+- Sprint test-2: tests de server logic con `shiny::testServer()`.
+  Cubre `mod_calidad_panel_server` (switch trimestral/anual del dataset,
+  filtro por años y dúos, outputs KPI) y `armo_base_panel(window="anual")`
+  con parquet fixture sintético (filter pushdown, drop de cols
+  anio_0/trim_0, errores). Suite pasa a **185 tests verde**.
+  `mod_analisis_*_server` se difieren a Sprint test-3 (E2E con
+  shinytest2 es más rentable que pelear el mock de globales).
 
 ## [0.9.0] · 2026-05-04
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,9 +35,17 @@ Sprint A). Ver [CHANGELOG.md](CHANGELOG.md) para el detalle.
 
 ### Sprint test-2 · Server logic con testServer() (~3-4 hs)
 
-- [ ] Tests `mod_calidad_panel_server`, `mod_analisis_*_server`
-      (reactives, NO `update*()`)
-- [ ] Test de `armo_base_panel(window = "anual")` con `open_dataset`
+- [x] Tests `mod_calidad_panel_server` con `testServer()`: reactives
+      `df_calidad_actual()`, `datos_filtrados()`, KPIs.
+      Mock de globals + stub de `renderHighchart`. → 9 tests
+- [x] Test de `armo_base_panel(window = "anual")` con parquet fixture
+      sintético + `arrow::open_dataset`. Cubre filter pushdown, drop
+      de cols anio_0/trim_0, error si no existe el parquet, validación
+      de window. → 6 tests
+- [ ] Pendientes (diferidos): `mod_analisis_*_server` para los 3 módulos
+      (cond_act, cat_ocup, formalidad). Requieren mock de globals
+      complejo (df_cond_act, df_tasas_*, periodos_*). Cubrir con E2E
+      en Sprint test-3 sería más rentable que pelear el mock.
 
 ### Sprint test-3 · E2E con shinytest2 (~4-5 hs)
 

--- a/tests/testthat/test-armo_base_panel_anual.R
+++ b/tests/testthat/test-armo_base_panel_anual.R
@@ -1,0 +1,148 @@
+### Tests de armo_base_panel(window = "anual") (en ETL/99-functions.R).
+###
+### Modo runtime anual: lee data_output/panel_runtime_anual.parquet ON-DEMAND
+### con filter pushdown sobre (anio_0, trim_0). Hotfix v0.7.3 cambió de
+### arrow::read_parquet (carga el archivo entero) a arrow::open_dataset
+### (truly lazy, footprint mínimo).
+###
+### Estrategia: generar un parquet sintético chico en with_tempdir(), apuntar
+### PATH_PANEL_RUNTIME_ANUAL a ese path, y verificar:
+###   - filter pushdown sobre (anio_0, trim_0) devuelve solo el dúo pedido.
+###   - columnas anio_0/trim_0 se dropean del output (no contaminan el
+###     downstream que espera ESTADO, ESTADO_t1, etc.).
+###   - error claro cuando el parquet no existe.
+
+build_fixture_anual_parquet <- function(path) {
+  ### Schema mínimo del panel_runtime_anual.parquet. Incluye 3 dúos
+  ### sintéticos con valores diferenciables para verificar el filter.
+  fixture <- dplyr::bind_rows(
+    tibble::tibble(
+      anio_0 = 2022L, trim_0 = 1L,
+      CODUSU = c("A", "B"),
+      ESTADO    = c(1L, 2L),
+      ESTADO_t1 = c(1L, 1L),
+      PONDERA    = c(500, 600),
+      PONDERA_t1 = c(500, 600)
+    ),
+    tibble::tibble(
+      anio_0 = 2022L, trim_0 = 2L,
+      CODUSU = c("C", "D", "E"),
+      ESTADO    = c(1L, 1L, 3L),
+      ESTADO_t1 = c(1L, 3L, 3L),
+      PONDERA    = c(700, 800, 900),
+      PONDERA_t1 = c(700, 800, 900)
+    ),
+    tibble::tibble(
+      anio_0 = 2023L, trim_0 = 1L,
+      CODUSU = "F",
+      ESTADO    = 1L,
+      ESTADO_t1 = 1L,
+      PONDERA    = 1000,
+      PONDERA_t1 = 1000
+    )
+  )
+  arrow::write_parquet(fixture, path)
+  invisible(fixture)
+}
+
+
+test_that("armo_base_panel modo anual: filter pushdown sobre (anio_0, trim_0)", {
+  withr::with_tempdir({
+    path <- file.path(getwd(), "panel_anual.parquet")
+    build_fixture_anual_parquet(path)
+
+    ### Inyectar el path como global, simulando 01-extract.R en runtime.
+    withr::local_options(list())
+    assign("PATH_PANEL_RUNTIME_ANUAL", path, envir = .GlobalEnv)
+    withr::defer(rm("PATH_PANEL_RUNTIME_ANUAL", envir = .GlobalEnv))
+
+    out <- armo_base_panel(
+      anio_0      = 2022,
+      trimestre_0 = 2,
+      window      = "anual"
+    )
+
+    expect_s3_class(out, "tbl_df")
+    ### Solo las 3 filas del dúo 2022-T2.
+    expect_equal(nrow(out), 3)
+    expect_setequal(out$CODUSU, c("C", "D", "E"))
+  })
+})
+
+
+test_that("armo_base_panel modo anual: dropea las cols anio_0/trim_0 del output", {
+  withr::with_tempdir({
+    path <- file.path(getwd(), "panel_anual.parquet")
+    build_fixture_anual_parquet(path)
+
+    assign("PATH_PANEL_RUNTIME_ANUAL", path, envir = .GlobalEnv)
+    withr::defer(rm("PATH_PANEL_RUNTIME_ANUAL", envir = .GlobalEnv))
+
+    out <- armo_base_panel(
+      anio_0      = 2022,
+      trimestre_0 = 1,
+      window      = "anual"
+    )
+
+    expect_false("anio_0" %in% names(out))
+    expect_false("trim_0" %in% names(out))
+    ### Las cols del panel sí están.
+    expect_true(all(c("ESTADO", "ESTADO_t1", "PONDERA", "PONDERA_t1") %in% names(out)))
+  })
+})
+
+
+test_that("armo_base_panel modo anual: dúo no presente devuelve 0 filas", {
+  withr::with_tempdir({
+    path <- file.path(getwd(), "panel_anual.parquet")
+    build_fixture_anual_parquet(path)
+
+    assign("PATH_PANEL_RUNTIME_ANUAL", path, envir = .GlobalEnv)
+    withr::defer(rm("PATH_PANEL_RUNTIME_ANUAL", envir = .GlobalEnv))
+
+    out <- armo_base_panel(
+      anio_0      = 2099,  # año inexistente
+      trimestre_0 = 1,
+      window      = "anual"
+    )
+
+    expect_equal(nrow(out), 0)
+  })
+})
+
+
+test_that("armo_base_panel modo anual: error claro si no existe el parquet", {
+  withr::with_tempdir({
+    ### No creamos el parquet; apuntamos a un path inexistente.
+    path_fake <- file.path(getwd(), "no_existe.parquet")
+    assign("PATH_PANEL_RUNTIME_ANUAL", path_fake, envir = .GlobalEnv)
+    withr::defer(rm("PATH_PANEL_RUNTIME_ANUAL", envir = .GlobalEnv))
+
+    expect_error(
+      armo_base_panel(anio_0 = 2022, trimestre_0 = 1, window = "anual"),
+      "panel_runtime_anual.parquet no encontrado"
+    )
+  })
+})
+
+
+test_that("armo_base_panel modo runtime: error si window no es trimestral ni anual", {
+  expect_error(
+    armo_base_panel(anio_0 = 2022, trimestre_0 = 1, window = "diario"),
+    "window debe ser 'trimestral' o 'anual'"
+  )
+})
+
+
+test_that("armo_base_panel modo trimestral runtime: error si df_panel_runtime no existe", {
+  ### Caso defensivo: en CI no hay df_panel_runtime cargado. Verifica que
+  ### el mensaje sea informativo (apunta a 01-extract.R como remediación).
+  if (exists("df_panel_runtime", envir = .GlobalEnv)) {
+    skip("df_panel_runtime ya cargado en este entorno")
+  }
+
+  expect_error(
+    armo_base_panel(anio_0 = 2022, trimestre_0 = 1, window = "trimestral"),
+    "df_panel_runtime no disponible"
+  )
+})

--- a/tests/testthat/test-mod_calidad_panel_server.R
+++ b/tests/testthat/test-mod_calidad_panel_server.R
@@ -1,0 +1,257 @@
+### Tests de mod_calidad_panel_server() (en R/mod_calidad_panel.R).
+###
+### Estrategia: shiny::testServer() para testear los reactives expuestos
+### por el módulo. Limitaciones documentadas (ver ROADMAP.md):
+###   - testServer() NO refleja updateSelectInput() en session$input.
+###     Tests que dependen de eso → diferidos a Sprint test-3 (shinytest2).
+###
+### Lo que SÍ podemos verificar acá:
+###   - Switch del dataset según tipo_duo() (df_calidad_actual()).
+###   - datos_filtrados() respondiendo a input$anios e input$duos.
+###   - Outputs KPI (kpi_encontrado, kpi_inc_total, kpi_inc_sexo,
+###     kpi_inc_edad) calculando promedios sobre el filtro.
+
+### tests/testthat.R no source-ea mod_calidad_panel.R; lo hacemos acá.
+source(testthat::test_path("..", "..", "R", "mod_calidad_panel.R"))
+
+### Stubs para renderers UI-only que no nos interesa testear acá pero
+### que el moduleServer evalúa al inicializar (output$hc_calidad <-
+### renderHighchart(...)). Sin estos stubs, testServer falla con
+### "no se pudo encontrar la función renderHighchart" porque highcharter
+### no está cargado en el environment minimal de los tests.
+###
+### Los stubs solo proveen una signature compatible; el contenido del
+### render no se ejecuta a menos que accedamos al output, y nuestros
+### tests solo acceden a outputs renderText (kpi_*).
+if (!exists("renderHighchart", envir = .GlobalEnv, mode = "function")) {
+  assign(
+    "renderHighchart",
+    function(expr, ...) shiny::renderUI({ NULL }),
+    envir = .GlobalEnv
+  )
+}
+
+### --- Mocks de los datasets globales que consume el módulo ----------------
+###
+### El módulo lee df_calidad_panel y df_calidad_panel_anual del global env
+### (via 01-extract.R en la app real). Para tests inyectamos versiones
+### mínimas controladas. withr::defer asegura cleanup tras cada test.
+
+mock_calidad_globals <- function(env = parent.frame()) {
+  ### Schema de calidad_panel_pct_historico.csv (subset de cols usadas).
+  df_trim <- tibble::tibble(
+    periodo                = c("2024_t1-t2", "2024_t2-t3", "2024_t3-t4"),
+    anio_0                 = c(2024L, 2024L, 2024L),
+    trim_0                 = c(1L, 2L, 3L),
+    anio_1                 = c(2024L, 2024L, 2024L),
+    trim_1                 = c(2L, 3L, 4L),
+    pct_encontrado_n       = c(50.0, 60.0, 70.0),
+    pct_encontrado_pondera = c(48.0, 58.0, 68.0),
+    pct_inc_total          = c(4.0, 5.0, 6.0),
+    pct_inc_sexo           = c(1.0, 1.5, 2.0),
+    pct_inc_edad           = c(8.0, 9.0, 10.0)
+  )
+
+  df_anual <- tibble::tibble(
+    periodo                = c("2024_t1", "2024_t2"),
+    anio_0                 = c(2024L, 2024L),
+    trim_0                 = c(1L, 2L),
+    anio_1                 = c(2025L, 2025L),
+    trim_1                 = c(1L, 2L),
+    pct_encontrado_n       = c(40.0, 42.0),
+    pct_encontrado_pondera = c(39.0, 41.0),
+    pct_inc_total          = c(5.0, 6.0),    # mean = 5.5 (sin ambigüedad IEEE)
+    pct_inc_sexo           = c(1.2, 1.4),    # mean = 1.3
+    pct_inc_edad           = c(5.5, 5.7)     # mean = 5.6
+  )
+
+  ### Asignar a global con cleanup auto.
+  assign("df_calidad_panel", df_trim, envir = .GlobalEnv)
+  assign("df_calidad_panel_anual", df_anual, envir = .GlobalEnv)
+  withr::defer(rm("df_calidad_panel", envir = .GlobalEnv), envir = env)
+  withr::defer(rm("df_calidad_panel_anual", envir = .GlobalEnv), envir = env)
+
+  list(trim = df_trim, anual = df_anual)
+}
+
+
+### --- Tests --------------------------------------------------------------
+
+test_that("df_calidad_actual() devuelve dataset trimestral por default", {
+  mocks <- mock_calidad_globals()
+
+  shiny::testServer(
+    mod_calidad_panel_server,
+    args = list(tipo_duo = shiny::reactive("trimestral")),
+    expr = {
+      session$setInputs(duos = "todas", anios = c(2024, 2024))
+      ### df_calidad_actual() debe devolver el dataset trimestral.
+      df <- df_calidad_actual()
+      expect_equal(nrow(df), 3)
+      expect_equal(df$periodo, c("2024_t1-t2", "2024_t2-t3", "2024_t3-t4"))
+    }
+  )
+})
+
+
+test_that("df_calidad_actual() devuelve dataset anual cuando tipo_duo='anual'", {
+  mocks <- mock_calidad_globals()
+
+  shiny::testServer(
+    mod_calidad_panel_server,
+    args = list(tipo_duo = shiny::reactive("anual")),
+    expr = {
+      session$setInputs(duos = "todas", anios = c(2024, 2024))
+      df <- df_calidad_actual()
+      expect_equal(nrow(df), 2)
+      expect_equal(df$periodo, c("2024_t1", "2024_t2"))
+    }
+  )
+})
+
+
+test_that("datos_filtrados() respeta rango anios", {
+  mocks <- mock_calidad_globals()
+
+  ### Extender el mock para tener años distintos.
+  df_multi_anio <- dplyr::bind_rows(
+    mocks$trim,
+    tibble::tibble(
+      periodo = "2025_t1-t2", anio_0 = 2025L, trim_0 = 1L,
+      anio_1 = 2025L, trim_1 = 2L,
+      pct_encontrado_n = 75, pct_encontrado_pondera = 73,
+      pct_inc_total = 7, pct_inc_sexo = 2.5, pct_inc_edad = 11
+    )
+  )
+  assign("df_calidad_panel", df_multi_anio, envir = .GlobalEnv)
+
+  shiny::testServer(
+    mod_calidad_panel_server,
+    args = list(tipo_duo = shiny::reactive("trimestral")),
+    expr = {
+      session$setInputs(duos = "todas", anios = c(2024, 2024))
+      df <- datos_filtrados()
+      expect_true(all(df$anio_0 == 2024))
+      expect_equal(nrow(df), 3)
+
+      session$setInputs(anios = c(2025, 2025))
+      df <- datos_filtrados()
+      expect_true(all(df$anio_0 == 2025))
+      expect_equal(nrow(df), 1)
+    }
+  )
+})
+
+
+test_that("datos_filtrados() respeta selección de dúos específicos", {
+  mocks <- mock_calidad_globals()
+
+  shiny::testServer(
+    mod_calidad_panel_server,
+    args = list(tipo_duo = shiny::reactive("trimestral")),
+    expr = {
+      session$setInputs(duos = "t1-t2", anios = c(2024, 2024))
+      df <- datos_filtrados()
+      expect_equal(nrow(df), 1)
+      ### periodo es factor (orden por anio_0/trim_0); comparar como char.
+      expect_equal(as.character(df$periodo[1]), "2024_t1-t2")
+
+      session$setInputs(duos = c("t1-t2", "t2-t3"))
+      df <- datos_filtrados()
+      expect_equal(nrow(df), 2)
+    }
+  )
+})
+
+
+test_that("datos_filtrados() con duos='todas' incluye todos los dúos del rango", {
+  mocks <- mock_calidad_globals()
+
+  shiny::testServer(
+    mod_calidad_panel_server,
+    args = list(tipo_duo = shiny::reactive("trimestral")),
+    expr = {
+      session$setInputs(duos = "todas", anios = c(2024, 2024))
+      df <- datos_filtrados()
+      expect_equal(nrow(df), 3)
+    }
+  )
+})
+
+
+test_that("KPI outputs: promedio sobre filtro activo (trimestral)", {
+  mocks <- mock_calidad_globals()
+
+  shiny::testServer(
+    mod_calidad_panel_server,
+    args = list(tipo_duo = shiny::reactive("trimestral")),
+    expr = {
+      session$setInputs(duos = "todas", anios = c(2024, 2024))
+
+      ### Promedios esperados sobre las 3 filas trimestrales:
+      ###   pct_encontrado_n: mean(50, 60, 70) = 60.0
+      ###   pct_inc_total:    mean(4, 5, 6)    = 5.0
+      ###   pct_inc_sexo:     mean(1, 1.5, 2)  = 1.5
+      ###   pct_inc_edad:     mean(8, 9, 10)   = 9.0
+      expect_equal(output$kpi_encontrado, "60.0%")
+      expect_equal(output$kpi_inc_total, "5.0%")
+      expect_equal(output$kpi_inc_sexo, "1.5%")
+      expect_equal(output$kpi_inc_edad, "9.0%")
+    }
+  )
+})
+
+
+test_that("KPI outputs: cambian al filtrar por dúo específico", {
+  mocks <- mock_calidad_globals()
+
+  shiny::testServer(
+    mod_calidad_panel_server,
+    args = list(tipo_duo = shiny::reactive("trimestral")),
+    expr = {
+      session$setInputs(duos = "t1-t2", anios = c(2024, 2024))
+      ### Solo la primera fila (50, 4, 1, 8).
+      expect_equal(output$kpi_encontrado, "50.0%")
+      expect_equal(output$kpi_inc_total, "4.0%")
+      expect_equal(output$kpi_inc_sexo, "1.0%")
+      expect_equal(output$kpi_inc_edad, "8.0%")
+    }
+  )
+})
+
+
+test_that("KPI outputs: '—' cuando el filtro deja 0 filas", {
+  mocks <- mock_calidad_globals()
+
+  shiny::testServer(
+    mod_calidad_panel_server,
+    args = list(tipo_duo = shiny::reactive("trimestral")),
+    expr = {
+      ### Año fuera de rango → 0 filas.
+      session$setInputs(duos = "todas", anios = c(2030, 2030))
+      expect_equal(output$kpi_encontrado, "—")
+      expect_equal(output$kpi_inc_total, "—")
+      expect_equal(output$kpi_inc_sexo, "—")
+      expect_equal(output$kpi_inc_edad, "—")
+    }
+  )
+})
+
+
+test_that("KPI outputs: usar tipo_duo=anual cambia los valores", {
+  mocks <- mock_calidad_globals()
+
+  shiny::testServer(
+    mod_calidad_panel_server,
+    args = list(tipo_duo = shiny::reactive("anual")),
+    expr = {
+      session$setInputs(duos = "todas", anios = c(2024, 2024))
+
+      ### Promedios sobre las 2 filas anuales:
+      ###   pct_encontrado_n: mean(40, 42) = 41.0
+      ###   pct_inc_total:    mean(5, 6)   = 5.5
+      expect_equal(output$kpi_encontrado, "41.0%")
+      expect_equal(output$kpi_inc_total, "5.5%")
+    }
+  )
+})


### PR DESCRIPTION
## Summary

- **mod_calidad_panel_server (9 tests con testServer)**: switch trim/anual del dataset, filtrado por años + dúos, outputs KPI.
- **armo_base_panel(window=\"anual\") (6 tests)**: parquet fixture + arrow::open_dataset (filter pushdown, drop de anio_0/trim_0, errores). Cubre el hotfix v0.7.3.

mod_analisis_*_server (cond_act / cat_ocup / formalidad) se difieren a Sprint test-3: requieren mockear ~6 globales por módulo y el ROI es bajo vs cubrirlo con shinytest2 E2E.

Suite local: **185 tests PASS** (149 → 185).

## Test plan

- [x] Suite local pasa (`Rscript tests/testthat.R` → 185 PASS).
- [ ] CI (`tests-unit.yml`) verde con shiny + bslib ya en la lista de paquetes mínimos.
- [ ] No hay regresiones en tests previos (149 + 36 nuevos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)