### PR TITLE
refactor: barrer anti-patterns dplyr/purrr (#39, scope acotado)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ versionado [SemVer](https://semver.org/lang/es/) adaptado a app web:
 
 ## [Unreleased]
 
+### Changed
+
+- Sprint B · Calidad técnica (#39, scope acotado): pasada de
+  anti-patterns dplyr/purrr en todo el repo. `pmap_dfr` / `map_dfr`
+  reemplazados por `pmap()/map() |> list_rbind()` (10 ocurrencias en
+  ETL/04b, 05, 06, 07 y 99-functions). `group_by(X) |> mutate(...) |> ungroup()`
+  reemplazado por `mutate(..., .by = X)` en `preparo_base()` (2 casos).
+  `%>%` magrittr reemplazado por `|>` nativo en `df_to_annotations_labels()`
+  (3 líneas). Refactor sin cambio funcional: los 185 tests pasan igual.
+
 ### Added
 
 - Sprint B · Calidad técnica (#45): script `ETL/12-validate_paneles_runtime.R`

--- a/ETL/04b-add_pp05_vars.R
+++ b/ETL/04b-add_pp05_vars.R
@@ -64,7 +64,8 @@ descargar_pp05 <- function(anio, trim) {
 }
 
 descargas <- periodos_target |>
-  pmap_dfr(function(ANO4, TRIMESTRE) descargar_pp05(ANO4, TRIMESTRE))
+  pmap(function(ANO4, TRIMESTRE) descargar_pp05(ANO4, TRIMESTRE)) |>
+  list_rbind()
 
 cat("\nDescargas totales:", nrow(descargas), "filas\n")
 

--- a/ETL/05-build_panel_cat_ocup.R
+++ b/ETL/05-build_panel_cat_ocup.R
@@ -53,7 +53,7 @@ etiquetas_cat_ocup <- c("Patron", "Cuenta_propia", "Asalariado", "TFSR")
 categorias_sankey  <- etiquetas_cat_ocup  ### las 4 producen una vista del Sankey
 
 paneles_nuevos <- paneles |>
-  pmap_dfr(function(ANO4, TRIMESTRE, anio_post, trim_post, periodo, ...) {
+  pmap(function(ANO4, TRIMESTRE, anio_post, trim_post, periodo, ...) {
     cat(glue("  panel {periodo}... "))
 
     df_panel <- armo_base_panel(
@@ -70,16 +70,18 @@ paneles_nuevos <- paneles |>
       etiquetas = etiquetas_cat_ocup
     )
 
-    res <- map_dfr(categorias_sankey, function(cat) {
+    res <- map(categorias_sankey, function(cat) {
       tryCatch({
         armo_tabla_sankey(table = df_prep, categoria = cat) |>
           mutate(periodo = as.character(periodo))
       }, error = function(e) tibble())
-    })
+    }) |>
+      list_rbind()
 
     cat(nrow(res), "filas\n")
     res
-  })
+  }) |>
+  list_rbind()
 
 cat("\nFilas totales:", nrow(paneles_nuevos), "\n")
 

--- a/ETL/06-build_panel_formalidad.R
+++ b/ETL/06-build_panel_formalidad.R
@@ -46,7 +46,7 @@ etiquetas_formalidad <- c("Formal", "Informal")
 categorias_sankey   <- etiquetas_formalidad
 
 paneles_nuevos <- paneles |>
-  pmap_dfr(function(ANO4, TRIMESTRE, anio_post, trim_post, periodo, ...) {
+  pmap(function(ANO4, TRIMESTRE, anio_post, trim_post, periodo, ...) {
     cat(glue("  panel {periodo}... "))
 
     df_panel <- armo_base_panel(
@@ -63,16 +63,18 @@ paneles_nuevos <- paneles |>
       etiquetas = etiquetas_formalidad
     )
 
-    res <- map_dfr(categorias_sankey, function(cat) {
+    res <- map(categorias_sankey, function(cat) {
       tryCatch({
         armo_tabla_sankey(table = df_prep, categoria = cat) |>
           mutate(periodo = as.character(periodo))
       }, error = function(e) tibble())
-    })
+    }) |>
+      list_rbind()
 
     cat(nrow(res), "filas\n")
     res
-  })
+  }) |>
+  list_rbind()
 
 cat("\nFilas totales:", nrow(paneles_nuevos), "\n")
 

--- a/ETL/07-build_panel_formalidad_ampliada.R
+++ b/ETL/07-build_panel_formalidad_ampliada.R
@@ -50,7 +50,7 @@ etiquetas_formalidad <- c("Formal", "Informal")
 categorias_sankey   <- etiquetas_formalidad
 
 paneles_nuevos <- paneles |>
-  pmap_dfr(function(ANO4, TRIMESTRE, anio_post, trim_post, periodo, ...) {
+  pmap(function(ANO4, TRIMESTRE, anio_post, trim_post, periodo, ...) {
     cat(glue("  panel {periodo}... "))
 
     df_panel <- armo_base_panel(
@@ -68,16 +68,18 @@ paneles_nuevos <- paneles |>
       etiquetas = etiquetas_formalidad
     )
 
-    res <- map_dfr(categorias_sankey, function(cat) {
+    res <- map(categorias_sankey, function(cat) {
       tryCatch({
         armo_tabla_sankey(table = df_prep, categoria = cat) |>
           mutate(periodo = as.character(periodo))
       }, error = function(e) tibble())
-    })
+    }) |>
+      list_rbind()
 
     cat(nrow(res), "filas\n")
     res
-  })
+  }) |>
+  list_rbind()
 
 cat("\nFilas totales:", nrow(paneles_nuevos), "\n")
 

--- a/ETL/99-functions.R
+++ b/ETL/99-functions.R
@@ -117,7 +117,7 @@ regenerar_panel_historico <- function(path_csv, df_microdato,
   vars_panel <- unique(c("ESTADO", "PONDERA", var, vars_extra))
 
   paneles_nuevos <- paneles_a_calcular |>
-    purrr::pmap_dfr(function(ANO4, TRIMESTRE, anio_post, trim_post, periodo, ...) {
+    purrr::pmap(function(ANO4, TRIMESTRE, anio_post, trim_post, periodo, ...) {
       df_panel <- armo_base_panel(
         anio_0 = ANO4, trimestre_0 = TRIMESTRE,
         anio_1 = anio_post, trimestre_1 = trim_post,
@@ -133,13 +133,15 @@ regenerar_panel_historico <- function(path_csv, df_microdato,
         etiquetas = etiquetas
       )
 
-      purrr::map_dfr(categorias, function(cat) {
+      purrr::map(categorias, function(cat) {
         tryCatch({
           armo_tabla_sankey(table = df_prep, categoria = cat) |>
             dplyr::mutate(periodo = as.character(periodo))
         }, error = function(e) tibble::tibble())
-      })
-    })
+      }) |>
+        purrr::list_rbind()
+    }) |>
+    purrr::list_rbind()
 
   panel_actualizado <- dplyr::bind_rows(panel_existente, paneles_nuevos) |>
     dplyr::filter(from != "from")  # cleanup defensivo
@@ -203,7 +205,7 @@ build_tasas_historico <- function(df_microdato, var, etiquetas,
   vars_panel <- unique(c("ESTADO", "PONDERA", var, vars_extra))
 
   paneles |>
-    purrr::pmap_dfr(function(ANO4, TRIMESTRE, anio_post, trim_post, periodo, ...) {
+    purrr::pmap(function(ANO4, TRIMESTRE, anio_post, trim_post, periodo, ...) {
       df_panel <- armo_base_panel(
         anio_0 = ANO4, trimestre_0 = TRIMESTRE,
         anio_1 = anio_post, trimestre_1 = trim_post,
@@ -212,7 +214,7 @@ build_tasas_historico <- function(df_microdato, var, etiquetas,
         window = window
       )
 
-      purrr::map_dfr(etiquetas, function(cat) {
+      purrr::map(etiquetas, function(cat) {
         tryCatch({
           tasas <- arma_tasas_destacadas(df_panel, var, etiquetas, cat)
           tibble::tibble(
@@ -223,8 +225,10 @@ build_tasas_historico <- function(df_microdato, var, etiquetas,
             entrada = tasas$entrada
           )
         }, error = function(e) tibble::tibble())
-      })
-    })
+      }) |>
+        purrr::list_rbind()
+    }) |>
+    purrr::list_rbind()
 }
 
 
@@ -402,10 +406,10 @@ preparo_base <- function(df,
     tabla <- tabla |>
       summarise(casos = sum(PONDERA),
                 .by = c("ESTADO", "ESTADO_t1")) |>
-      group_by(ESTADO) |>
       mutate(porc_base = round(casos / sum(casos) * 100, 1),
              periodo_base = "t_anterior",
-             id = paste(ESTADO, ESTADO_t1, sep = " - ")) |> ungroup() |>
+             id = paste(ESTADO, ESTADO_t1, sep = " - "),
+             .by = ESTADO) |>
       select(ESTADO, ESTADO_t1, porc_base, id, periodo_base)
   }
 
@@ -413,10 +417,10 @@ preparo_base <- function(df,
     tabla <- tabla |>
       summarise(casos = sum(PONDERA_t1),
                 .by = c("ESTADO_t1", "ESTADO")) |>
-      group_by(ESTADO_t1) |>
       mutate(porc_base = round(casos / sum(casos) * 100, 1),
              periodo_base = "t_posterior",
-             id = paste(ESTADO, ESTADO_t1, sep = " - ")) |> ungroup() |>
+             id = paste(ESTADO, ESTADO_t1, sep = " - "),
+             .by = ESTADO_t1) |>
       select(ESTADO, ESTADO_t1, porc_base, id, periodo_base)
   }
 
@@ -639,14 +643,12 @@ regenerar_calidad_panel <- function(path_csv, df_microdato,
 
 ### Notas para highcharter
 df_to_annotations_labels <- function(df, xAxis = 0, yAxis = 0) {
-  
   stopifnot(hasName(df, "x"))
   stopifnot(hasName(df, "y"))
   stopifnot(hasName(df, "text"))
-  
-  df %>% 
-    rowwise() %>% 
-    mutate(point = list(list(x = x, y = y, xAxis = 0, yAxis = 0))) %>% 
-    select(-x, -y)  
-  
+
+  df |>
+    rowwise() |>
+    mutate(point = list(list(x = x, y = y, xAxis = 0, yAxis = 0))) |>
+    select(-x, -y)
 }

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,11 +108,13 @@ completo.
   empieza 2003-T3), tamaño/atrición (n>5000 por dúo, ratio anual/trim
   ∈ [40%, 120%]), cross-val tasas CSV vs parquet (tolerancia 0.5 pp).
   Integrado al workflow `update_eph_data.yml` como gate post 09b.
-- [ ] **#39** Pasada integral (parcial) · ~2 hs (scope acotado).
-  Anti-patterns dplyr/purrr (`map_dfr` → `map() |> list_rbind()`,
-  `group_by + ungroup` → `.by`, joins `c("a"="b")` → `join_by()`),
-  comentarios obsoletos. Diferido a otro sprint: CSS muerto, perf
-  con profvis, accesibilidad, tests (ya cubierto por Sprint testing).
+- [x] **#39** Pasada integral (parcial) · ~2 hs (scope acotado).
+  Anti-patterns dplyr/purrr barridos del repo: 10 ocurrencias de
+  `pmap_dfr` / `map_dfr` → `pmap()/map() |> list_rbind()`,
+  2 ocurrencias de `group_by + ungroup` → `.by`,
+  3 líneas de `%>%` magrittr → `|>` nativo. 185 tests siguen verde
+  (refactor sin cambio funcional). Diferido a otro sprint:
+  CSS muerto, perf con profvis, accesibilidad, deps no usadas.
 
 **Cuándo:** después de Sprint A. Ya tendremos ~1.5 meses de GA4
 acumulado para guiar optimizaciones con datos reales.


### PR DESCRIPTION
## Summary

Cierra parcialmente issue #39 (Sprint B · Calidad técnica). Pasada mecánica para alinear el código a las convenciones tidyverse modernas (ver `.claude/rules/r-conventions.md`). Refactor sin cambio funcional.

**Cambios:**

| Anti-pattern | Reemplazo | Ocurrencias |
|---|---|---|
| `pmap_dfr` / `map_dfr` (deprecated purrr 1.0) | `pmap()/map() \\|> list_rbind()` | 10 |
| `group_by(X) \\|> mutate(...) \\|> ungroup()` | `mutate(..., .by = X)` | 2 |
| `%>%` magrittr | `\\|>` nativo | 3 |

Archivos tocados: `ETL/04b, 05, 06, 07-build_*.R` y `ETL/99-functions.R`.

**Diferido a otro sprint** (no parte de este PR): CSS muerto, perf con profvis, accesibilidad WCAG, dependencias no usadas, refactor `mod_analisis()` genérico (#12 / Sprint C).

## Test plan

- [x] Suite local pasa: 185 tests verde antes y después.
- [x] Grep verifica: 0 ocurrencias de los anti-patterns en R/ y ETL/.
- [ ] CI tests-unit.yml verde sobre este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)