### PR TITLE
docs: actualizar ROADMAP, ESTADO, CHANGELOG post Sprint Testing + B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ versionado [SemVer](https://semver.org/lang/es/) adaptado a app web:
 
 ## [Unreleased]
 
+(Nada pendiente de release. Próximas líneas de trabajo en
+[ROADMAP.md](ROADMAP.md): Sprint C refactor `mod_analisis()` genérico,
+Sprint D decisión metodológica formal/informal, Sprint E features
+mayores #29/#30).
+
+## [0.9.1] · 2026-05-09
+
+Trabajo interno (no user-visible): cierre de Sprint Testing y Sprint B.
+Shipped vía PR #67 (testing infra + restore GA4) y PR #70 (Sprint B).
+
 ### Changed
 
 - Sprint B · Calidad técnica (#39, scope acotado): pasada de
@@ -35,24 +45,33 @@ versionado [SemVer](https://semver.org/lang/es/) adaptado a app web:
   como gate después de regenerar los parquets y antes de crear el PR.
   Si alguna validación falla, el workflow aborta y prod no recibe
   datos corruptos.
-- Sprint test-1 batch 3: tests para `arma_matriz_transicion`,
-  `build_tasas_historico`, `regenerar_calidad_panel`, `formato_delta`,
-  `sankey_label_legible`, `sankey_nodes_orden`. Suite de testthat pasa
-  de 79 a 149 tests verde.
-- Sprint test-2: tests de server logic con `shiny::testServer()`.
-  Cubre `mod_calidad_panel_server` (switch trimestral/anual del dataset,
-  filtro por años y dúos, outputs KPI) y `armo_base_panel(window="anual")`
-  con parquet fixture sintético (filter pushdown, drop de cols
-  anio_0/trim_0, errores). Suite pasa a 185 tests verde.
-  `mod_analisis_*_server` se difieren a Sprint test-3 (E2E con
-  shinytest2 es más rentable que pelear el mock de globales).
-- Sprint test-3 lite: 3 tests E2E con `shinytest2` + Chromote para
-  smoke (boot + input `tipo_duo` registrado), toggle tipo_duo
-  (estado trim ↔ anual), y módulo Calidad (KPI render tras navegar
-  al panel). Suite total: **192 tests** (185 unit + 7 E2E con
-  `RUN_E2E=true`). Workflow CI separado `tests-e2e.yml` con
-  `workflow_dispatch` + cron semanal (no en cada PR para no
-  inflar el ciclo).
+- Sprint Testing (#61): pirámide de tests automatizados en 3 capas.
+  - **test-1** Funciones puras (149 tests testthat): `agrega_vars_derivadas`,
+    `armo_tabla_sankey`, `duos_disponibles_por_anio`, `duo_label`,
+    `arma_tasas_destacadas`, `regenerar_panel_historico`,
+    `arma_matriz_transicion`, `build_tasas_historico`,
+    `regenerar_calidad_panel`, `formato_delta`, `sankey_label_legible`,
+    `sankey_nodes_orden`.
+  - **test-2** Server logic con `shiny::testServer()` (+36 tests):
+    `mod_calidad_panel_server` (switch trimestral/anual, filtros,
+    outputs KPI con stub de `renderHighchart`) y
+    `armo_base_panel(window="anual")` con parquet fixture sintético
+    (filter pushdown, drop de cols anio_0/trim_0, errores).
+  - **test-3 lite** E2E con `shinytest2` + Chromote (+7 expects):
+    smoke (input `tipo_duo` registrado), toggle tipo_duo
+    (trim ↔ anual y vuelve), módulo Calidad (KPI render tras navegar
+    al panel).
+  - Total: **192 tests** (185 unit + 7 E2E con `RUN_E2E=true`).
+  - CI: workflow `tests-unit.yml` corre en cada PR; `tests-e2e.yml`
+    con `workflow_dispatch` + cron semanal (no en cada PR para no
+    inflar el ciclo).
+
+### Fixed
+
+- GA4 measurement ID restaurado en producción (`R/utils_analytics.R`).
+  Master tenía `GA4_MEASUREMENT_ID <- ""` desde PR #50 (2026-05-03),
+  con tracking roto durante 4 días. Restaurado a `"G-NQPB4BHWMM"` en
+  el merge staging → master del 2026-05-08.
 
 ## [0.9.0] · 2026-05-04
 

--- a/ESTADO.md
+++ b/ESTADO.md
@@ -1,22 +1,27 @@
 # Estado · shiny_eph_panel
 
-> Última actualización: 2026-05-01
+> Última actualización: 2026-05-09
 
 ## Live
 
 - **App productiva:** https://estacionr.shinyapps.io/shiny_eph_panel/
+- **App staging:** https://estacionr.shinyapps.io/shiny_eph_panel_staging/
 - **Repo:** https://github.com/Estacion-R/shiny_eph_panel
-- **Datos hasta:** 2025-T4 (próxima publicación INDEC esperada agosto/septiembre 2026)
+- **Versión actual:** v0.9.0 + Sprint Testing + Sprint B (deployadas
+  al merge de PR #70 el 2026-05-09).
+- **Datos hasta:** 2025-T4 (próxima publicación INDEC esperada
+  agosto/septiembre 2026).
 
 ## Secciones de la app
 
 | Sección | Estado |
 |---|---|
 | Inicio (landing) | OK |
-| Análisis de panel · Condición de actividad | OK |
-| Análisis de panel · Categoría ocupacional | OK |
-| Análisis de panel · Formal / Informal (clásica + ampliada) | OK |
-| Análisis de panel · **Calidad de la muestra** | OK (nuevo, 2026-05-01, issue #36) |
+| Análisis de panel · Condición de actividad | OK (toggle Interanual) |
+| Análisis de panel · Categoría ocupacional | OK (toggle Interanual) |
+| Análisis de panel · Formal / Informal (clásica + ampliada) | OK (toggle Interanual) |
+| Análisis de panel · **Calidad de la muestra** | OK (toggle Interanual) |
+| Análisis de panel · **Datos descargables** | OK (Parquet/CSV gzip, intertrim + anual) |
 | Análisis transversal · Indicadores básicos | Próximamente (placeholder) |
 | Análisis transversal · Calidad del empleo | Próximamente (placeholder) |
 | Metadata · Glosario + Definiciones + links | OK |
@@ -25,58 +30,107 @@
 
 | Componente | Cuándo | Hace |
 |---|---|---|
-| `update_eph_data.yml` | Día 5 cada mes, 12 UTC | Detecta nuevos trimestres → PR auto-merge → deploy |
-| `deploy_shinyapps.yml` | On-push a master con paths relevantes | Deploy directo |
+| `update_eph_data.yml` | Día 5 cada mes, 12 UTC | Detecta nuevos trimestres → regenera CSVs + parquets runtime → **valida con `ETL/12-validate_paneles_runtime.R`** → PR auto-merge → deploy |
+| `deploy_shinyapps.yml` | On-push a master con paths relevantes | Deploy directo a producción |
+| `deploy_shinyapps_staging.yml` | On-push a staging con paths relevantes | Deploy directo a staging |
+| `tests-unit.yml` | Cada PR + push a master/staging | Corre 185 tests testthat (funciones puras + server logic) |
+| `tests-e2e.yml` | `workflow_dispatch` + cron domingo 06:00 UTC | Corre 7 expects E2E con `shinytest2` (no en cada PR para no inflar el ciclo) |
 | Routine `trig_01Y3TmHxhCjecnGg8qRmNFac` | Día 7 cada mes, 14 ART | Audita el ciclo y reporta |
+| Routine health check mensual | Día 1 cada mes | Genera reporte de salud y abre PR |
 
 ## Datos pre-procesados (cargados al iniciar la app)
 
-| CSV / Parquet | Filas | Generado por |
+| Archivo | Tamaño | Generado por |
 |---|---|---|
-| `data_output/panel_runtime.parquet` | ~varios MB | `ETL/09-build_paneles_runtime.R` |
-| `data_output/panel_cond_act_historico.csv` | ~80 paneles × 9 categorías | `03-update_data.R` (cron) |
-| `data_output/panel_cat_ocup_historico.csv` | ídem | `03-update_data.R` |
-| `data_output/panel_formalidad_historico.csv` | ídem | `03-update_data.R` |
-| `data_output/panel_formalidad_ampliada_historico.csv` | desde 2023-T4 | `03-update_data.R` |
-| `data_output/tasas_*_historico.csv` × 4 | tasas Persistencia/Salida/Entrada | `08-build_tasas_historico.R` |
-| `data_output/calidad_panel_pct_historico.csv` | 83 dúos | `10-build_calidad_panel.R` + cron |
-| `data_output/df_tasas_mt.parquet` | tasas mercado de trabajo | `03-update_data.R` |
+| `panel_runtime.parquet` (intertrim) | 22 MB | `ETL/09-build_paneles_runtime.R` |
+| `panel_runtime_anual.parquet` (anual) | 16 MB | `ETL/09b-build_paneles_runtime_anual.R` |
+| `panel_cond_act_historico.csv` + variante `_anual` | ~80 paneles × N categorías | `ETL/04-build_panel_cond_act.R` |
+| `panel_cat_ocup_historico.csv` + variante `_anual` | ídem | `ETL/05-build_panel_cat_ocup.R` |
+| `panel_formalidad_historico.csv` + variante `_anual` | ídem | `ETL/06-build_panel_formalidad.R` |
+| `panel_formalidad_ampliada_historico.csv` + variante `_anual` | desde 2023-T4 | `ETL/07-build_panel_formalidad_ampliada.R` |
+| `tasas_*_historico.csv` × 4 (intertrim + anual) | tasas Persistencia/Salida/Entrada | `ETL/08-build_tasas_historico.R` |
+| `calidad_panel_pct_historico.csv` + variante `_anual` | 83 dúos | `ETL/10-build_calidad_panel.R` |
+| `df_tasas_mt.parquet` | tasas mercado de trabajo | `03-update_data.R` |
 
-## Issues abiertos
+## Cobertura de tests
 
-- **#35** — Sección de descarga del dataset con paneles (idea, no priorizado).
-- **#37** — Decisión sobre si excluir paneles inconsistentes del cálculo de tasas en los 3 mods analíticos (parcial: ya se mide y se muestra el % en Calidad de la muestra; falta la decisión de aplicarlo o no a los cálculos).
+| Capa | Cantidad | Cuándo corre |
+|---|---|---|
+| Funciones puras (testthat) | 149 | `tests-unit.yml` en cada PR |
+| Server logic (`shiny::testServer`) | +36 (185 total) | `tests-unit.yml` en cada PR |
+| E2E (`shinytest2` + Chromote) | +7 expects (192 total con `RUN_E2E=true`) | `tests-e2e.yml` (manual + cron semanal) |
 
-## Issues cerrados recientemente
+Detalle por archivo en `tests/testthat/`. Pirámide cerrada en
+Sprint Testing (#61) durante 2026-05-04 a 2026-05-07.
 
-- **#37** — Calidad: % de paneles encontrados con inconsistencias entre t0 y t1 (2026-05-01) — total (flag eph) + sexo distinto + edad imposible. 4 KPIs nuevas + chart histórico en el panel Calidad de la muestra. Datos: ~5.9% de inconsistencia total mediana, 10.8% por edad, 1.6% por sexo.
-- **#36** — Calidad: histórico de % personas-panel encontradas (2026-05-01) — implementado con eje 0-50% en lugar de stack 100% (más correcto conceptualmente: el complemento es diseño muestral, no atrición).
+## Issues abiertos relevantes
+
+- **#5** Chatbot ellmer + Gemini — backlog wishlist, sin priorizar.
+- **#12** Refactor a `mod_analisis()` genérico — pre-requisito para
+  #29 y #30. Próximo Sprint C.
+- **#13** Formal/Informal "tiene descuento jubilatorio" — bloqueado
+  por 5 preguntas metodológicas. Sprint D cuando haya tiempo.
+- **#29** Filtros sociodemográficos — Sprint E. Bloqueado por #12.
+- **#30** Pobreza/indigencia — Sprint E dedicado. Bloqueado por #12.
+- **#37** Tratamiento de paneles inconsistentes en cálculo de tasas
+  — pendiente decisión metodológica (parcial: ya se mide y muestra
+  el % en Calidad).
+- **#39** Revisión integral (parcial cerrada con scope acotado) —
+  diferido a otro sprint: CSS muerto, perf con profvis,
+  accesibilidad, deps no usadas.
+- **#42** Migrar Glosario/Definiciones a `.md`/`.qmd` — solo cuando
+  crezca el contenido.
+- **#43** Extender glosario con variables nuevas — convención: aplicar
+  al cerrar features con vars nuevas (#29, #30).
+
+> Nota: issues #44, #45, #46, #47, #48 y #61 ya shippeadas en master
+> pero quedaron OPEN en GitHub. Cerrarlas a mano en próxima sesión
+> de mantenimiento.
+
+## Issues cerrados recientemente (cronológico)
+
+- **#48** Pipeline mensual auto-regenera parquets runtime
+  (2026-05-04, Sprint A · v0.9.0).
+- **#46** Película + Tasas en modo Interanual (2026-05-04, Sprint A · v0.9.0).
+- **#47** Calidad + Datos descargables en modo Interanual
+  (2026-05-04, Sprint A · v0.9.0).
+- **#61** Setup testing automatizado (2026-05-07, Sprint Testing).
+- **#45** Validación ETL paneles intertrim + anual (2026-05-08,
+  Sprint B). Gate en `update_eph_data.yml`.
+- **#39** Pasada de anti-patterns dplyr/purrr (2026-05-09, Sprint B,
+  scope acotado).
+- **#37** Calidad: % de paneles con inconsistencias entre t0 y t1
+  (2026-05-01).
+- **#36** Calidad: histórico de % personas-panel encontradas
+  (2026-05-01).
 
 ## Pendientes técnicos menores
 
-- Comentario obsoleto en `ETL/09-build_paneles_runtime.R:24` dice "carga df_eph_full" pero el `01-extract.R` actual ya no lo carga (el script 09 hace su propio `arrow::read_parquet`). No bloquea, solo confunde.
-- `ETL/10-build_calidad_panel.R` no está en `.rscignore`. Va al bundle pero no se ejecuta en runtime; consistente con 05-09 que tampoco están excluidos. Costo despreciable.
+- Comentario obsoleto en `ETL/09-build_paneles_runtime.R:24` dice
+  "carga df_eph_full" pero `01-extract.R` ya no lo carga (el script 09
+  hace su propio `arrow::read_parquet`). No bloquea, solo confunde.
+- `ETL/10-build_calidad_panel.R` no está en `.rscignore`. Va al bundle
+  pero no se ejecuta en runtime; consistente con 05-09 que tampoco
+  están excluidos. Costo despreciable.
+- Verificar si staging GA4 ID contamina métricas de prod (ambas
+  branches comparten `G-NQPB4BHWMM` desde el fix del 2026-05-08).
 
 ## Comunicaciones y lanzamiento
 
 | Material | Ubicación | Estado |
 |---|---|---|
-| **Post 1° de mayo** (Día del Trabajador) | `comunicaciones/2026-05-01_post_dia_trabajador.md` | ✅ Cerrado (pendiente publicación LinkedIn 2026-05-01) |
-| **Artículo blog técnico** (panel + EPH) | Web/Blog (pendiente) | 🔴 En progreso (deadline 2026-05-02, falta dato merma panel) |
+| Post 1° de mayo (Día del Trabajador) | `comunicaciones/2026-05-01_post_dia_trabajador.md` | Pendiente publicación |
+| Post novedades mayo (v0.9.0 + descargas) | `comunicaciones/2026-05-04_post_novedades_mayo.md` | Pendiente publicación |
+| Cambios a comunicar (registro vivo) | `comunicaciones/cambios_a_comunicar.md` | En uso |
+| Artículo blog técnico (panel + EPH) | Web/Blog (pendiente) | En progreso |
 
-## Sesión 2026-05-01 (resumen)
+## Próximos pasos sugeridos
 
-Hitos cerrados durante la sesión:
-
-- **UX overhaul pre-launch**: lotes 1-4 (logo Estación R · alert removido · footer · landing rediseñado · jerarquía value boxes · matriz con etiquetas legibles · typos · microcopia).
-- **Reorganización del sidebar**: "Sobre la app" → "Inicio" como landing; +Info absorbido por Metadata; "Análisis transversal" agregado como menú placeholder.
-- **Sección Definiciones expandida** según anexo INDEC 2016 sobre intervención + nota propia sobre significancia estadística (no hay metodología oficial INDEC para errores estándar de panel).
-- **Tarjeta "Población" como primera** de las 4 en Foto · orden estable de categorías en Sankey via `sankey_nodes_orden()` · tabs migradas a `navset_card_underline`.
-- **Fix OOM en producción**: pre-cómputo de paneles armados en `panel_runtime.parquet` (~21 MB) reemplaza la carga del microdato (~570 MB en RAM). `armo_base_panel()` refactorizado con modos runtime / legacy. Resuelve definitivamente el OOM en plan free de shinyapps.io.
-- **Issue #37**: panel Calidad ahora mide % de paneles con inconsistencias entre t0 y t1 (total / sexo / edad) + 3 nuevas value boxes y chart histórico.
-
-**Pendiente apertura próxima sesión:**
-
-- Decidir tratamiento de paneles inconsistentes en el cálculo de tasas (issue #37, parcial).
-- Cleanup técnico menor: comentario obsoleto en `ETL/09-build_paneles_runtime.R:24` y `ETL/10-build_calidad_panel.R` no listado en `.rscignore`.
-- Revisión visual completa de los 3 mods en producción con los 4 KPI reordenados + Sankey con orden estable + tabs underline.
+- **Sprint C** · Refactor a `mod_analisis()` genérico (#12). Habilita
+  #29 (filtros sociodemo) y #30 (pobreza/indigencia) sin triplicar
+  cambios.
+- **Sprint D** · Decisión metodológica formal/informal (#13). Sesión
+  enfocada cuando haya tiempo de revisar las 5 preguntas pendientes.
+- Revisar GA4 después de ~1.5 meses de tracking productivo para guiar
+  optimizaciones con datos reales.
+- Cerrar issues #44, #45, #46, #47, #48, #61 en GitHub (housekeeping).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,123 +1,87 @@
 # Roadmap — shiny_eph_panel
 
 > Plan de prioridades vivo. Se actualiza al cerrar cada sprint.
-> Última revisión: **2026-05-04**.
+> Última revisión: **2026-05-09**.
 
 ---
 
 ## Versión actual
 
-**v0.8.1** en master/staging. PR #60 pendiente con v0.9.0 (cierre
-Sprint A). Ver [CHANGELOG.md](CHANGELOG.md) para el detalle.
+**v0.9.0** en master + producción. Cierra Sprint A (#44 Tipo de dúo
+end-to-end). Sobre esa base se agregaron, sin bumpear versión por ser
+trabajo interno: Sprint Testing (3 capas, 192 tests) y Sprint B
+(#45 validación ETL como gate + #39 barrido de anti-patterns
+dplyr/purrr). Detalle en [CHANGELOG.md](CHANGELOG.md).
 
 ---
 
-## Sprint Testing · Sumar capa de tests automatizados (#61)
+## Sprints completados
 
-**Objetivo:** sumar tests en 3 capas. Stack confirmado por research:
+### Sprint A · Tipo de dúo end-to-end (#44) · cerrado 2026-05-04
+
+Toggle Interanual habilitado en toda la app: Foto, Película, Tasas,
+Calidad de la muestra y descargas en sección Datos.
+
+- [x] **#48** Pipeline mensual auto-regenera parquets runtime.
+- [x] **#46** Fase 2: Película + Tasas en modo Interanual.
+- [x] **#47** Fase 3: Calidad + Datos descargables en modo Interanual.
+
+Shipped en v0.9.0 (PR #60).
+
+### Sprint Testing · Cobertura automatizada (#61) · cerrado 2026-05-07
+
+Pirámide de tests en 3 capas: 185 unit + 7 E2E = 192 tests. Stack:
 `testthat 3.x` + `shiny::testServer()` + `shinytest2`.
 
-### Sprint test-1 · Funciones puras (~4-6 hs)
+- [x] **test-1** · Funciones puras (149 tests). Cubre
+      `agrega_vars_derivadas`, `armo_tabla_sankey`,
+      `duos_disponibles_por_anio`, `duo_label`, `arma_tasas_destacadas`,
+      `regenerar_panel_historico`, `arma_matriz_transicion`,
+      `build_tasas_historico`, `regenerar_calidad_panel`,
+      `formato_delta`, `sankey_label_legible`, `sankey_nodes_orden`.
+- [x] **test-2** · Server logic con `testServer()` (+36 tests).
+      `mod_calidad_panel_server` (reactives + KPIs con stub de
+      `renderHighchart`) y `armo_base_panel(window="anual")` con
+      parquet fixture sintético (filter pushdown, drop de cols
+      anio_0/trim_0, errores).
+- [x] **test-3 lite** · E2E con `shinytest2` (+7 expects). Smoke,
+      toggle tipo_duo (trim ↔ anual), render de KPI tras navegar a
+      Calidad.
+- [x] CI: workflow `tests-unit.yml` corre en cada PR;
+      `tests-e2e.yml` corre vía `workflow_dispatch` + cron semanal
+      (no en cada PR para no inflar el ciclo).
+- [x] Guard `RUN_E2E=true` para que dev local no arrastre Chromote.
 
-- [x] Setup `tests/testthat/` + runner + helper-fixtures
-- [x] Fixture sintética `panel_mock.rds` (100 individuos × 3 ondas)
-- [x] Tests batch 1: `agrega_vars_derivadas`, `armo_tabla_sankey`,
-      `duos_disponibles_por_anio`, `duo_label` → 42 tests
-- [x] Tests batch 2: `arma_tasas_destacadas`, `regenerar_panel_historico`,
-      `tests/testthat.R` aislado de `00-libraries.R` → 79 tests
-- [x] Tests batch 3: `arma_matriz_transicion`, `build_tasas_historico`,
-      `regenerar_calidad_panel`, `formato_delta`, `sankey_label_legible`,
-      `sankey_nodes_orden` → **149 tests PASS**
-- [x] CI: GitHub Actions `tests-unit.yml` ejecuta en cada push a master/staging
-- [ ] Pendiente para Sprint test-2: `armo_base_panel` modo legacy
-      (requiere `eph::organize_panels()` real, conviene cubrir junto
-      con runtime mode usando `testServer`).
+**Diferido a futuros sprints:**
+- `mod_analisis_*_server` (los 3 mods): mock de globales complejo,
+  más rentable cubrir con E2E si aparece la necesidad.
+- E2E de descarga (Chromote tiene quirks con `downloadHandler` +
+  `file.copy`).
+- Codecov action (no justifica el costo hoy).
+- Snapshot testing de los charts Foto / Película (regresión #40),
+  hoy frágil.
 
-### Sprint test-2 · Server logic con testServer() (~3-4 hs)
+**Pitfall confirmado:** `testServer()` NO refleja
+`updateSelectInput()` en `session$input`. Tests del toggle Tipo de
+dúo solo confiables con `shinytest2` AppDriver.
 
-- [x] Tests `mod_calidad_panel_server` con `testServer()`: reactives
-      `df_calidad_actual()`, `datos_filtrados()`, KPIs.
-      Mock de globals + stub de `renderHighchart`. → 9 tests
-- [x] Test de `armo_base_panel(window = "anual")` con parquet fixture
-      sintético + `arrow::open_dataset`. Cubre filter pushdown, drop
-      de cols anio_0/trim_0, error si no existe el parquet, validación
-      de window. → 6 tests
-- [ ] Pendientes (diferidos): `mod_analisis_*_server` para los 3 módulos
-      (cond_act, cat_ocup, formalidad). Requieren mock de globals
-      complejo (df_cond_act, df_tasas_*, periodos_*). Cubrir con E2E
-      en Sprint test-3 sería más rentable que pelear el mock.
+### Sprint B · Calidad técnica · cerrado 2026-05-09
 
-### Sprint test-3 lite · E2E con shinytest2 (~2 hs)
+- [x] **#45** Validación ETL paneles intertrim + anual.
+      Script `ETL/12-validate_paneles_runtime.R` con 29 tests
+      testthat: schema (31 cols + tipos), cobertura (≥75 dúos trim,
+      ≥65 anual, empieza 2003-T3), tamaño/atrición (n>5000 por dúo,
+      ratio anual/trim ∈ [40%, 120%]), cross-val tasas CSV vs parquet
+      (tolerancia 0.5 pp). Integrado a `update_eph_data.yml` como
+      gate post 09b: si falla, el workflow aborta y prod no recibe
+      datos corruptos.
+- [x] **#39** Barrido de anti-patterns (scope acotado).
+      10 ocurrencias `pmap_dfr` / `map_dfr` → `pmap()/map() |> list_rbind()`,
+      2 `group_by + ungroup` → `.by`, 3 `%>%` magrittr → `|>` nativo.
+      Refactor sin cambio funcional: los 185 tests siguen verde.
 
-Versión recortada del Sprint original (5-7 tests + Codecov diferidos):
-foco en cubrir el smoke + regresión del toggle Tipo de dúo + render de
-output post-navegación. ROI suficiente para el costo de mantenimiento.
-
-- [x] 3 tests E2E: smoke (input tipo_duo registrado), toggle tipo_duo
-      (state cambia trim ↔ anual y vuelve), módulo Calidad (KPI
-      renderiza valor numérico tras navegar al panel) → 7 expects
-- [x] CI: workflow `tests-e2e.yml` con `workflow_dispatch` + schedule
-      semanal (domingo 06:00 UTC). NO corre en cada PR.
-- [x] Guard `RUN_E2E=true` env var: corrida default de
-      `tests/testthat.R` salta los E2E (rápido para dev local).
-
-**Diferido (puede sumarse en Sprint test-4 si aparece la necesidad):**
-- Tests E2E de descarga (shinytest2 + Chromote tiene quirks con
-  `downloadHandler` que copia archivos vía `file.copy`).
-- Codecov action (precio actual del proyecto no lo justifica).
-- Tests E2E para Foto / Película línea charts (cubrir regresión #40
-  con interacción real de Highcharts; requiere snapshot testing
-  estable, hoy frágil).
-
-**Pitfall confirmado por research:** `testServer()` NO refleja
-`updateSelectInput()` en `session$input`. Tests del toggle Tipo de dúo
-solo confiables con `shinytest2` AppDriver.
-
----
-
-## Sprint A · Cerrar feature Tipo de dúo (#44 completo)
-
-**Objetivo:** terminar de habilitar el toggle Interanual en toda la
-app. Hoy solo Foto soporta Interanual; Película y Tasas muestran un
-banner azul "no soportado".
-
-**Orden:**
-
-1. **#48** Pipeline mensual auto-regenera parquets runtime · ~1 hr.
-   Sin esto, cada update mensual deja CSVs nuevos y parquets viejos.
-2. **#46** Fase 2: Película + Tasas en modo Interanual · ~2-3 hs.
-   Genera CSVs anuales pre-calculados, conecta los módulos, quita
-   el banner.
-3. **#47** Fase 3: Calidad + Datos descargables en modo Interanual ·
-   ~1-2 hs. Cierra el feature visual end-to-end.
-
-**Por qué este orden:** #48 antes de #46 porque automatizar la
-regeneración del panel anual es prerequisito para que los CSVs
-anuales no entren en drift cuando se cargue un trimestre nuevo.
-
----
-
-## Sprint B · Calidad técnica
-
-**Objetivo:** robustez y limpieza después de meter Tipo de dúo
-completo.
-
-- [x] **#45** Validación ETL paneles intertrim + anual · ~2 hs.
-  Script `ETL/12-validate_paneles_runtime.R` con 29 tests testthat:
-  schema (31 cols + tipos), cobertura (≥75 dúos trim, ≥65 anual,
-  empieza 2003-T3), tamaño/atrición (n>5000 por dúo, ratio anual/trim
-  ∈ [40%, 120%]), cross-val tasas CSV vs parquet (tolerancia 0.5 pp).
-  Integrado al workflow `update_eph_data.yml` como gate post 09b.
-- [x] **#39** Pasada integral (parcial) · ~2 hs (scope acotado).
-  Anti-patterns dplyr/purrr barridos del repo: 10 ocurrencias de
-  `pmap_dfr` / `map_dfr` → `pmap()/map() |> list_rbind()`,
-  2 ocurrencias de `group_by + ungroup` → `.by`,
-  3 líneas de `%>%` magrittr → `|>` nativo. 185 tests siguen verde
-  (refactor sin cambio funcional). Diferido a otro sprint:
-  CSS muerto, perf con profvis, accesibilidad, deps no usadas.
-
-**Cuándo:** después de Sprint A. Ya tendremos ~1.5 meses de GA4
-acumulado para guiar optimizaciones con datos reales.
+**Diferido a otro sprint:** CSS muerto, perf con profvis,
+accesibilidad, dependencias no usadas.
 
 ---
 
@@ -178,9 +142,8 @@ deflactor IPC). Diferencial fuerte vs reportes oficiales de INDEC.
 
 ## Cómo se mantiene este documento
 
-- Al cerrar un sprint, mover los issues completados a la sección
-  `## Sprints completados` (a crear cuando suceda) con el rango de
-  fechas.
+- Al cerrar un sprint, mover sus issues a `## Sprints completados`
+  con la fecha de cierre y el PR/versión donde shippeó.
 - Al re-priorizar, actualizar el orden y agregar nota de cuándo y
   por qué.
 - Si entra un issue urgente fuera de plan (bug crítico, requerimiento


### PR DESCRIPTION
## Summary

Actualiza la documentación viva del proyecto para reflejar lo que está
en master tras Sprint A (v0.9.0), Sprint Testing (#61) y Sprint B
(#45 + #39). No toca código.

- **ROADMAP.md**: nueva sección "Sprints completados" con A, Testing
  y B; versión actual y última revisión a 2026-05-09; bloque
  duplicado de Sprint A/B removido.
- **ESTADO.md**: reescritura completa (estaba en 2026-05-01).
  Pipeline automático suma `tests-unit.yml`, `tests-e2e.yml` y la
  validación gate `ETL/12-validate_paneles_runtime.R`. Datos
  pre-procesados incluyen variantes `_anual` y
  `panel_runtime_anual.parquet`. Nueva sección "Cobertura de tests"
  (149 unit + 36 server + 7 E2E). Flag de housekeeping pendiente:
  cerrar #44/#45/#46/#47/#48/#61 en GitHub. Pendientes técnicos
  agrega verificar contaminación GA4 staging↔prod.
- **CHANGELOG.md**: cortado `[0.9.1] · 2026-05-09` con Sprint
  Testing + Sprint B + Fixed (restore GA4 tras 4 días con tracking
  roto). `[Unreleased]` queda con puntero a ROADMAP.

## Test plan

- [ ] Mergear a staging.
- [ ] Cuando se promueva staging → master no se requiere deploy
      (cambios solo en docs); `deploy_shinyapps.yml` no dispara
      sobre `*.md` salvo que estén en paths relevantes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)