### PR TITLE
Promover a producción: descarga directa del panel completo (#87) + pin terra

### DIFF
--- a/.github/workflows/deploy_shinyapps.yml
+++ b/.github/workflows/deploy_shinyapps.yml
@@ -63,6 +63,19 @@ jobs:
           install.packages("rsconnect")
         shell: Rscript {0}
 
+      - name: Pinear terra a 1.9-11 (workaround build GDAL en shinyapps.io)
+        run: |
+          # terra >= 1.9-34 no compila en el builder de shinyapps.io por una
+          # incompatibilidad con la GDAL de su imagen base
+          # (GDALMDArray::AsClassicDataset). terra entra como dependencia
+          # transitiva de eph (sf/sp). Forzamos 1.9-11, que sí compila, para
+          # que rsconnect::deployApp lo registre con esa versión en el manifest
+          # y shinyapps.io reconstruya con ella. Revisar/levantar el pin cuando
+          # Posit actualice su imagen o salga un terra parcheado.
+          if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes")
+          remotes::install_version("terra", version = "1.9-11", upgrade = "never")
+        shell: Rscript {0}
+
       - name: Configurar cuenta shinyapps.io
         env:
           SHINYAPPS_NAME: ${{ secrets.SHINYAPPS_NAME }}

--- a/.github/workflows/deploy_shinyapps_staging.yml
+++ b/.github/workflows/deploy_shinyapps_staging.yml
@@ -60,6 +60,19 @@ jobs:
           install.packages("rsconnect")
         shell: Rscript {0}
 
+      - name: Pinear terra a 1.9-11 (workaround build GDAL en shinyapps.io)
+        run: |
+          # terra >= 1.9-34 no compila en el builder de shinyapps.io por una
+          # incompatibilidad con la GDAL de su imagen base
+          # (GDALMDArray::AsClassicDataset). terra entra como dependencia
+          # transitiva de eph (sf/sp). Forzamos 1.9-11, que sí compila, para
+          # que rsconnect::deployApp lo registre con esa versión en el manifest
+          # y shinyapps.io reconstruya con ella. Revisar/levantar el pin cuando
+          # Posit actualice su imagen o salga un terra parcheado.
+          if (!requireNamespace("remotes", quietly = TRUE)) install.packages("remotes")
+          remotes::install_version("terra", version = "1.9-11", upgrade = "never")
+        shell: Rscript {0}
+
       - name: Configurar cuenta shinyapps.io
         env:
           SHINYAPPS_NAME: ${{ secrets.SHINYAPPS_NAME }}

--- a/R/mod_armador.R
+++ b/R/mod_armador.R
@@ -122,6 +122,13 @@ ARMADOR_EDAD_MAX <- 110L
 ### (criterio alineado con #29: subconjuntos con pocos casos son frágiles).
 ARMADOR_N_MIN <- 100L
 
+### Umbral de subconjunto grande. Por encima se sugiere usar la descarga
+### directa del panel completo (file.copy del parquet de disco) en vez del
+### collect() del subconjunto, que con casi todo el panel tensiona el free
+### tier de shinyapps.io (#87, OOM reportado por usuaria). El panel completo
+### ronda 1,86 M (intertrim) / 1,41 M (interanual) filas.
+ARMADOR_N_GRANDE <- 800000L
+
 
 ### downloadButton con tracking GA4 client-side. Mismo patrón que la sección
 ### Datos (R/panel_descarga.R): el onclick burbujea desde el wrapper, dispara
@@ -843,6 +850,38 @@ mod_armador_ui <- function(id) {
             label = "diccionario de variables (CSV)"
           )
         ), "."
+      ),
+
+      ### --- Descarga directa del panel completo, sin filtros (#87) ----------
+      ### Sirve el parquet pre-armado de disco tal cual (file.copy en el
+      ### server, sin collect() ni materialización en R), así bajar el panel
+      ### entero es instantáneo y no tensiona el free tier como sí lo haría un
+      ### collect() del subconjunto "todo seleccionado". Restaura la descarga
+      ### directa que ofrecía la vieja sección Datos antes del Armador.
+      tags$div(
+        class = "armador-descarga-completo",
+        tags$p(
+          class = "armador-descarga-completo-titulo",
+          icon("database"),
+          tags$span("¿Necesitás el panel completo, sin filtrar?")
+        ),
+        tags$p(
+          class = "armador-descarga-completo-desc",
+          "Bajá el dataset entero ya armado (todas las columnas, esquema ",
+          "runtime). Es una descarga directa: rápida y sin riesgo de que se ",
+          "caiga el servidor. Filtralo después con R, Python o Stata."
+        ),
+        tags$div(
+          class = "armador-descarga-botones",
+          armador_download_btn(ns("descarga_completo_trim"),
+                               "Panel intertrimestral (~22 MB)",
+                               format = "parquet_completo_trim",
+                               icon_name = "file-zipper"),
+          armador_download_btn(ns("descarga_completo_anual"),
+                               "Panel interanual (~16 MB)",
+                               format = "parquet_completo_anual",
+                               icon_name = "file-zipper")
+        )
       )
     )
   )
@@ -1042,6 +1081,24 @@ mod_armador_server <- function(id) {
             "Muestra chica (menos de %d filas): leé los resultados con cautela.",
             ARMADOR_N_MIN))
         )
+      } else if (n > ARMADOR_N_GRANDE) {
+        ### Subconjunto casi-completo: el collect() de descarga es pesado y, en
+        ### el free tier, riesgoso. Sugerimos la descarga directa del panel
+        ### completo (más abajo), que sirve el parquet de disco sin tocar RAM
+        ### (#87). Tono informativo (no de error): la descarga del subconjunto
+        ### sigue funcionando, sólo ofrecemos un camino más robusto.
+        tags$div(
+          class = "armador-warning armador-warning-info",
+          role  = "status",
+          icon("circle-info"),
+          tags$span(
+            sprintf("Tu selección es grande (%s filas). ",
+                    format(n, big.mark = ".", scientific = FALSE)),
+            "Si querés (casi) todo el panel, te conviene la ",
+            tags$strong("descarga directa del panel completo"),
+            " (al pie de esta sección): es instantánea y no sobrecarga el servidor."
+          )
+        )
       } else {
         NULL
       }
@@ -1126,6 +1183,40 @@ mod_armador_server <- function(id) {
       },
       content  = function(file) readr::write_csv(armador_diccionario_salida(), file),
       contentType = "text/csv"
+    )
+
+    ### --- Descarga directa del panel COMPLETO, sin filtros (#87) -----------
+    ### Sirve el parquet pre-armado de data_output/ tal cual con file.copy():
+    ### NO hay collect() ni materialización en R, así que el footprint de RAM
+    ### es ~0 y bajar el panel entero no puede tumbar el free tier (a
+    ### diferencia del collect() del subconjunto cuando el usuario no filtra).
+    ### El esquema es el runtime crudo, documentado por el diccionario.
+    descarga_completo_handler <- function(ruta, nombre) {
+      downloadHandler(
+        filename    = function() nombre,
+        content     = function(file) {
+          ### Defensa: si el parquet faltara del bundle, escribir un archivo
+          ### vacío deja una pista clara en vez de colgar el handler.
+          if (file.exists(ruta)) {
+            file.copy(ruta, file, overwrite = TRUE)
+          } else {
+            warning("Parquet de panel completo no encontrado: ", ruta)
+            file.create(file)
+          }
+        },
+        contentType = "application/octet-stream"
+      )
+    }
+
+    output$descarga_completo_trim <- descarga_completo_handler(
+      "data_output/panel_runtime.parquet",
+      paste0("eph_panel_completo_intertrim_", format(Sys.Date(), "%Y%m%d"),
+             ".parquet")
+    )
+    output$descarga_completo_anual <- descarga_completo_handler(
+      "data_output/panel_runtime_anual.parquet",
+      paste0("eph_panel_completo_interanual_", format(Sys.Date(), "%Y%m%d"),
+             ".parquet")
     )
 
     ### Contrato hacia la Fase 3 (integración al hub).

--- a/R/mod_armador.R
+++ b/R/mod_armador.R
@@ -744,8 +744,8 @@ mod_armador_ui <- function(id) {
       radioButtons(
         inputId  = ns("etiquetas"),
         label    = "Categorías de las variables:",
-        choices  = c("Con etiquetas" = "si", "Sin etiquetas (códigos)" = "no"),
-        selected = "si",
+        choices  = c("Sin etiquetas (códigos)" = "no", "Con etiquetas" = "si"),
+        selected = "no",
         inline   = TRUE
       ),
       tags$span(class = "armador-etiquetas-nota",

--- a/tests/testthat/test-e2e-app.R
+++ b/tests/testthat/test-e2e-app.R
@@ -111,6 +111,24 @@ test_that("Armador: arranca en el último panel y la descarga entrega archivo", 
 })
 
 
+test_that("Armador: descarga directa del panel completo entrega el parquet (#87)", {
+  app <- new_app("armador_panel_completo")
+  withr::defer(app$stop())
+
+  app$click("go_datos")
+  app$wait_for_idle(timeout = 10000)
+
+  ### Botón de descarga directa del panel completo intertrimestral: sirve el
+  ### parquet de disco tal cual (file.copy, sin collect()). Debe entregar el
+  ### dataset entero, sustancialmente más pesado que un subconjunto filtrado
+  ### (el parquet de runtime ronda ~22 MB). Verificamos que entrega un archivo
+  ### grande, lo que confirma que sirve el panel completo y no un vacío.
+  destino <- app$get_download("armador-descarga_completo_trim")
+  expect_true(file.exists(destino))
+  expect_gt(file.size(destino), 1e6)  # > 1 MB: es el panel completo, no un stub
+})
+
+
 test_that("Armador: el filtro de Aglomerado reduce el conteo (#78)", {
   app <- new_app("armador_aglomerado")
   withr::defer(app$stop())

--- a/www/style.css
+++ b/www/style.css
@@ -1485,3 +1485,44 @@ input:checked + .slider:before {
   text-decoration: underline;
 }
 
+/* ----- Aviso informativo (variante azul del warning ámbar): subconjunto
+   grande → sugerir descarga directa (#87) ----- */
+.armador-warning-info {
+  border: 1px solid #C2CCFF;
+  border-left: 4px solid #405BFF;
+  background: #F4F6FF;
+  color: #29324D;
+}
+.armador-warning-info .fa,
+.armador-warning-info .fas {
+  color: #405BFF;
+}
+
+/* ----- Descarga directa del panel completo, sin filtros (#87) -----
+   Sección separada visualmente del bloque de descarga del subconjunto. */
+.armador-descarga-completo {
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid rgba(25, 25, 25, 0.08);
+}
+.armador-descarga-completo-titulo {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 600;
+  font-size: 1rem;
+  color: #191919;
+  margin-bottom: 0.4rem;
+}
+.armador-descarga-completo-titulo .fa,
+.armador-descarga-completo-titulo .fas {
+  color: #405BFF;
+}
+.armador-descarga-completo-desc {
+  font-size: 0.9rem;
+  color: #555;
+  line-height: 1.45;
+  margin-bottom: 0.75rem;
+  max-width: 640px;
+}
+

--- a/www/style.css
+++ b/www/style.css
@@ -1455,6 +1455,12 @@ input:checked + .slider:before {
   overflow-x: auto;
   max-width: 100%;
 }
+/* Tabla de preview (reactable): fuente compacta para que entren más columnas
+   sin scroll y se lea como una tabla de datos, no como texto de cuerpo. */
+.armador-preview-scroll .rt-th,
+.armador-preview-scroll .rt-td {
+  font-size: 0.8rem;
+}
 
 /* ----- Descarga ----- */
 .armador-descarga {
@@ -1524,5 +1530,24 @@ input:checked + .slider:before {
   line-height: 1.45;
   margin-bottom: 0.75rem;
   max-width: 640px;
+}
+/* Jerarquía: la descarga del subconjunto filtrado es el flujo principal del
+   Armador (botones azul sólido). La descarga del panel completo es la
+   alternativa, así que va en estilo secundario (outline) para distinguirla
+   sin competir por atención. Rellena en hover. */
+.armador-descarga-completo .btn-descarga {
+  background: #FFFFFF;
+  color: #405BFF !important;
+  border: 1.5px solid #405BFF;
+}
+.armador-descarga-completo .btn-descarga:hover {
+  background: #405BFF;
+  color: #FFFFFF !important;
+  box-shadow: 0 2px 8px rgba(64, 91, 255, 0.25);
+}
+.armador-descarga-completo .btn-descarga .fa,
+.armador-descarga-completo .btn-descarga .fas,
+.armador-descarga-completo .btn-descarga .far {
+  color: inherit;
 }
 

--- a/www/style.css
+++ b/www/style.css
@@ -1461,6 +1461,12 @@ input:checked + .slider:before {
 .armador-preview-scroll .rt-td {
   font-size: 0.8rem;
 }
+/* Una línea por celda: el CODUSU largo dejaba de leerse partido en 3 líneas e
+   inflaba la altura de cada fila (~66px). Con nowrap las filas quedan
+   compactas; el contenedor scrollea horizontal si alguna columna no entra. */
+.armador-preview-scroll .rt-td-inner {
+  white-space: nowrap;
+}
 
 /* ----- Descarga ----- */
 .armador-descarga {


### PR DESCRIPTION
Promueve a producción, ya validado en staging (deploy success + HTTP 200).

## Contenido

### Descarga directa del panel completo (#87) · feedback de Camila
- Botones de descarga directa (intertrim ~22 MB, interanual ~16 MB) que sirven el parquet de disco con `file.copy()` (cero RAM, no tumban el free tier).
- Aviso informativo cuando el subconjunto filtrado supera 800k filas, sugiriendo la descarga directa.
- UX: default del toggle "sin etiquetas", preview compacto (fuente 0.8rem + filas en una línea), jerarquía de botones (subconjunto sólido / completo outline).

### Fix de deploy: pin de terra 1.9-11
El deploy fallaba al reconstruir la imagen porque `terra 1.9-34` no compila en el builder de shinyapps.io (incompatibilidad con su GDAL; `GDALMDArray::AsClassicDataset`). terra entra como dependencia transitiva de `eph`, la app no lo usa directo. Ambos workflows (staging + prod) ahora fuerzan `terra 1.9-11` antes del deploy. Levantar el pin cuando Posit actualice su imagen.

## Validación

- Unit 323 · e2e 338 · CI verde.
- Staging: deploy success (con el pin) + HTTP 200.

## Pendiente tras merge

Responderle a Camila por mail avisando de la descarga directa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)